### PR TITLE
Adds number sizes, changes inferred type to inferred types (Addresses #12)

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
 	"editorConfig": true,
-	"printWidth": 100,
+	"printWidth": 120,
 	"trailingComma": "all",
 	"singleQuote": true
 }

--- a/compile.ts
+++ b/compile.ts
@@ -34,9 +34,7 @@ void (async (): Promise<void> => {
 	// if we're analyzing an inline string, we allow all ASTs in an ASTProgram
 	const isThisAnInlineAnalysis = args.includes('-i');
 
-	const options = isThisAnInlineAnalysis
-		? getOptionsForInlineAnalysis(args)
-		: await getOptionsForFileAnalysis(args);
+	const options = isThisAnInlineAnalysis ? getOptionsForInlineAnalysis(args) : await getOptionsForFileAnalysis(args);
 
 	// if the user only wants to lexify, we don't need to do anything else
 	// this only applies for inline analyses
@@ -60,10 +58,7 @@ void (async (): Promise<void> => {
 					try {
 						await fsPromises.writeFile(outfile, output);
 					} catch (err) {
-						console.error(
-							`%cError writing Tokens to ${outfile}: ${(err as Error).message}`,
-							'color: red',
-						);
+						console.error(`%cError writing Tokens to ${outfile}: ${(err as Error).message}`, 'color: red');
 						process.exit(1);
 					}
 				}
@@ -114,9 +109,7 @@ void (async (): Promise<void> => {
 					{
 						const parserError = parserResult.error as ParserError;
 
-						console.groupCollapsed(
-							`Error[${parserError.getErrorCode()}]: ${parserError.message}`,
-						);
+						console.groupCollapsed(`Error[${parserError.getErrorCode()}]: ${parserError.message}`);
 						parserError
 							.getContext()
 							.toStringArray(parserError.message)
@@ -165,10 +158,7 @@ async function runSemanticAnalyzer(cst: Node, parser: Parser, isThisAnInlineAnal
 					try {
 						await fsPromises.writeFile(outfile, output);
 					} catch (err) {
-						console.error(
-							`%cError writing AST to ${outfile}: ${(err as Error).message}`,
-							'color: red',
-						);
+						console.error(`%cError writing AST to ${outfile}: ${(err as Error).message}`, 'color: red');
 						return 1;
 					}
 				}

--- a/examples/example1/main.ast.json
+++ b/examples/example1/main.ast.json
@@ -30,6 +30,13 @@
 					{
 						"kind": "VariableDeclaration",
 						"modifiers": [],
+						"mutable": false,
+						"identifiersList": [
+							{
+								"kind": "Identifier",
+								"name": "myFoo"
+							}
+						],
 						"declaredTypes": [],
 						"initialValues": [
 							{
@@ -48,13 +55,8 @@
 								"args": []
 							}
 						],
-						"inferredTypes": [],
-						"mutable": false,
-						"identifiersList": [
-							{
-								"kind": "Identifier",
-								"name": "myFoo"
-							}
+						"inferredPossibleTypes": [
+							[]
 						]
 					},
 					{
@@ -99,6 +101,10 @@
 		{
 			"kind": "ClassDeclaration",
 			"modifiers": [],
+			"name": {
+				"kind": "Identifier",
+				"name": "Foo"
+			},
 			"typeParams": [
 				{
 					"kind": "Identifier",
@@ -108,16 +114,16 @@
 			"extends": [
 				{
 					"kind": "TypeInstantiationExpression",
+					"base": {
+						"kind": "Identifier",
+						"name": "Bar"
+					},
 					"typeArgs": [
 						{
 							"kind": "Identifier",
 							"name": "A"
 						}
-					],
-					"base": {
-						"kind": "Identifier",
-						"name": "Bar"
-					}
+					]
 				},
 				{
 					"kind": "Identifier",
@@ -127,32 +133,35 @@
 			"implements": [
 				{
 					"kind": "TypeInstantiationExpression",
+					"base": {
+						"kind": "Identifier",
+						"name": "AbstractFooBar"
+					},
 					"typeArgs": [
 						{
 							"kind": "Identifier",
 							"name": "A"
 						}
-					],
-					"base": {
-						"kind": "Identifier",
-						"name": "AbstractFooBar"
-					}
+					]
 				},
 				{
 					"kind": "Identifier",
 					"name": "AnotherAbstractClass"
 				}
 			],
-			"name": {
-				"kind": "Identifier",
-				"name": "Foo"
-			},
 			"body": {
 				"kind": "BlockStatement",
 				"expressions": [
 					{
 						"kind": "VariableDeclaration",
 						"modifiers": [],
+						"mutable": true,
+						"identifiersList": [
+							{
+								"kind": "Identifier",
+								"name": "bar"
+							}
+						],
 						"declaredTypes": [],
 						"initialValues": [
 							{
@@ -160,23 +169,25 @@
 								"value": "baz"
 							}
 						],
-						"inferredTypes": [
-							{
-								"kind": "TypePrimitive",
-								"type": "string"
-							}
-						],
-						"mutable": true,
-						"identifiersList": [
-							{
-								"kind": "Identifier",
-								"name": "bar"
-							}
+						"inferredPossibleTypes": [
+							[
+								{
+									"kind": "TypePrimitive",
+									"type": "string"
+								}
+							]
 						]
 					},
 					{
 						"kind": "VariableDeclaration",
 						"modifiers": [],
+						"mutable": false,
+						"identifiersList": [
+							{
+								"kind": "Identifier",
+								"name": "isDone?"
+							}
+						],
 						"declaredTypes": [
 							{
 								"kind": "TypePrimitive",
@@ -189,22 +200,21 @@
 								"value": true
 							}
 						],
-						"inferredTypes": [
-							{
-								"kind": "TypePrimitive",
-								"type": "bool"
-							}
-						],
-						"mutable": false,
-						"identifiersList": [
-							{
-								"kind": "Identifier",
-								"name": "isDone?"
-							}
+						"inferredPossibleTypes": [
+							[
+								{
+									"kind": "TypePrimitive",
+									"type": "bool"
+								}
+							]
 						]
 					},
 					{
 						"kind": "FunctionDeclaration",
+						"joeDoc": {
+							"kind": "JoeDoc",
+							"content": "/** method with no args */"
+						},
 						"modifiers": [],
 						"name": {
 							"kind": "Identifier",
@@ -214,8 +224,8 @@
 						"params": [],
 						"returnTypes": [
 							{
-								"kind": "TypePrimitive",
-								"type": "number"
+								"kind": "TypeNumber",
+								"size": "uint64"
 							}
 						],
 						"body": {
@@ -224,23 +234,52 @@
 								{
 									"kind": "VariableDeclaration",
 									"modifiers": [],
+									"mutable": false,
+									"identifiersList": [
+										{
+											"kind": "Identifier",
+											"name": "size"
+										}
+									],
 									"declaredTypes": [],
 									"initialValues": [
 										{
 											"kind": "WhenExpression",
+											"expression": {
+												"kind": "Identifier",
+												"name": "someNumber"
+											},
 											"cases": [
 												{
 													"kind": "WhenCase",
 													"values": [
 														{
 															"kind": "NumberLiteral",
-															"format": "int",
-															"value": 1
+															"value": 1,
+															"possibleSizes": [
+																"int8",
+																"int16",
+																"int32",
+																"int64",
+																"uint8",
+																"uint16",
+																"uint32",
+																"uint64"
+															]
 														},
 														{
 															"kind": "NumberLiteral",
-															"format": "int",
-															"value": 2
+															"value": 2,
+															"possibleSizes": [
+																"int8",
+																"int16",
+																"int32",
+																"int64",
+																"uint8",
+																"uint16",
+																"uint32",
+																"uint64"
+															]
 														}
 													],
 													"consequent": {
@@ -255,13 +294,31 @@
 															"kind": "RangeExpression",
 															"lower": {
 																"kind": "NumberLiteral",
-																"format": "int",
-																"value": 3
+																"value": 3,
+																"possibleSizes": [
+																	"int8",
+																	"int16",
+																	"int32",
+																	"int64",
+																	"uint8",
+																	"uint16",
+																	"uint32",
+																	"uint64"
+																]
 															},
 															"upper": {
 																"kind": "NumberLiteral",
-																"format": "int",
-																"value": 10
+																"value": 10,
+																"possibleSizes": [
+																	"int8",
+																	"int16",
+																	"int32",
+																	"int64",
+																	"uint8",
+																	"uint16",
+																	"uint32",
+																	"uint64"
+																]
 															}
 														}
 													],
@@ -275,8 +332,17 @@
 													"values": [
 														{
 															"kind": "NumberLiteral",
-															"format": "int",
-															"value": 11
+															"value": 11,
+															"possibleSizes": [
+																"int8",
+																"int16",
+																"int32",
+																"int64",
+																"uint8",
+																"uint16",
+																"uint32",
+																"uint64"
+															]
 														}
 													],
 													"consequent": {
@@ -296,45 +362,57 @@
 														"value": "off the charts"
 													}
 												}
-											],
-											"expression": {
-												"kind": "Identifier",
-												"name": "someNumber"
-											}
+											]
 										}
 									],
-									"inferredTypes": [],
-									"mutable": false,
-									"identifiersList": [
-										{
-											"kind": "Identifier",
-											"name": "size"
-										}
+									"inferredPossibleTypes": [
+										[]
 									]
 								},
 								{
 									"kind": "VariableDeclaration",
 									"modifiers": [],
+									"mutable": true,
+									"identifiersList": [
+										{
+											"kind": "Identifier",
+											"name": "myArray"
+										}
+									],
 									"declaredTypes": [],
 									"initialValues": [
 										{
 											"kind": "ArrayExpression",
-											"type": {
-												"kind": "TypePrimitive",
-												"type": "number"
-											},
 											"items": [
 												{
 													"kind": "NumberLiteral",
-													"format": "int",
-													"value": 1
+													"value": 1,
+													"possibleSizes": [
+														"int8",
+														"int16",
+														"int32",
+														"int64",
+														"uint8",
+														"uint16",
+														"uint32",
+														"uint64"
+													]
 												},
 												{
 													"kind": "PostfixIfStatement",
 													"expression": {
 														"kind": "NumberLiteral",
-														"format": "int",
-														"value": 10
+														"value": 10,
+														"possibleSizes": [
+															"int8",
+															"int16",
+															"int32",
+															"int64",
+															"uint8",
+															"uint16",
+															"uint32",
+															"uint64"
+														]
 													},
 													"test": {
 														"kind": "MemberExpression",
@@ -349,83 +427,119 @@
 												},
 												{
 													"kind": "NumberLiteral",
-													"format": "int",
-													"value": 3
+													"value": 3,
+													"possibleSizes": [
+														"int8",
+														"int16",
+														"int32",
+														"int64",
+														"uint8",
+														"uint16",
+														"uint32",
+														"uint64"
+													]
+												}
+											],
+											"possibleTypes": [
+												{
+													"kind": "TypeNumber",
+													"size": "int8"
+												},
+												{
+													"kind": "TypeNumber",
+													"size": "int16"
+												},
+												{
+													"kind": "TypeNumber",
+													"size": "int32"
+												},
+												{
+													"kind": "TypeNumber",
+													"size": "int64"
+												},
+												{
+													"kind": "TypeNumber",
+													"size": "uint8"
+												},
+												{
+													"kind": "TypeNumber",
+													"size": "uint16"
+												},
+												{
+													"kind": "TypeNumber",
+													"size": "uint32"
+												},
+												{
+													"kind": "TypeNumber",
+													"size": "uint64"
 												}
 											]
 										}
 									],
-									"inferredTypes": [
-										{
-											"kind": "ArrayOf",
-											"type": {
-												"kind": "TypePrimitive",
-												"type": "number"
+									"inferredPossibleTypes": [
+										[
+											{
+												"kind": "ArrayOf",
+												"type": {
+													"kind": "TypeNumber",
+													"size": "int8"
+												}
+											},
+											{
+												"kind": "ArrayOf",
+												"type": {
+													"kind": "TypeNumber",
+													"size": "int16"
+												}
+											},
+											{
+												"kind": "ArrayOf",
+												"type": {
+													"kind": "TypeNumber",
+													"size": "int32"
+												}
+											},
+											{
+												"kind": "ArrayOf",
+												"type": {
+													"kind": "TypeNumber",
+													"size": "int64"
+												}
+											},
+											{
+												"kind": "ArrayOf",
+												"type": {
+													"kind": "TypeNumber",
+													"size": "uint8"
+												}
+											},
+											{
+												"kind": "ArrayOf",
+												"type": {
+													"kind": "TypeNumber",
+													"size": "uint16"
+												}
+											},
+											{
+												"kind": "ArrayOf",
+												"type": {
+													"kind": "TypeNumber",
+													"size": "uint32"
+												}
+											},
+											{
+												"kind": "ArrayOf",
+												"type": {
+													"kind": "TypeNumber",
+													"size": "uint64"
+												}
 											}
-										}
-									],
-									"mutable": true,
-									"identifiersList": [
-										{
-											"kind": "Identifier",
-											"name": "myArray"
-										}
+										]
 									]
 								},
 								{
 									"kind": "VariableDeclaration",
 									"modifiers": [],
-									"declaredTypes": [],
-									"initialValues": [
-										{
-											"kind": "RangeExpression",
-											"lower": {
-												"kind": "NumberLiteral",
-												"format": "int",
-												"value": 1
-											},
-											"upper": {
-												"kind": "MemberExpression",
-												"object": {
-													"kind": "Identifier",
-													"name": "myArray"
-												},
-												"property": {
-													"kind": "NumberLiteral",
-													"format": "int",
-													"value": 2
-												}
-											}
-										},
-										{
-											"kind": "RangeExpression",
-											"lower": {
-												"kind": "MemberExpression",
-												"object": {
-													"kind": "Identifier",
-													"name": "myArray"
-												},
-												"property": {
-													"kind": "NumberLiteral",
-													"format": "int",
-													"value": 1
-												}
-											},
-											"upper": {
-												"kind": "NumberLiteral",
-												"format": "int",
-												"value": 0
-											}
-										}
-									],
-									"inferredTypes": [
-										{
-											"kind": "TypeRange"
-										},
-										{
-											"kind": "TypeRange"
-										}
-									],
 									"mutable": true,
 									"identifiersList": [
 										{
@@ -436,11 +550,109 @@
 											"kind": "Identifier",
 											"name": "countDown"
 										}
+									],
+									"declaredTypes": [],
+									"initialValues": [
+										{
+											"kind": "RangeExpression",
+											"lower": {
+												"kind": "NumberLiteral",
+												"value": 1,
+												"possibleSizes": [
+													"int8",
+													"int16",
+													"int32",
+													"int64",
+													"uint8",
+													"uint16",
+													"uint32",
+													"uint64"
+												]
+											},
+											"upper": {
+												"kind": "MemberExpression",
+												"object": {
+													"kind": "Identifier",
+													"name": "myArray"
+												},
+												"property": {
+													"kind": "NumberLiteral",
+													"value": 2,
+													"possibleSizes": [
+														"int8",
+														"int16",
+														"int32",
+														"int64",
+														"uint8",
+														"uint16",
+														"uint32",
+														"uint64"
+													]
+												}
+											}
+										},
+										{
+											"kind": "RangeExpression",
+											"lower": {
+												"kind": "MemberExpression",
+												"object": {
+													"kind": "Identifier",
+													"name": "myArray"
+												},
+												"property": {
+													"kind": "NumberLiteral",
+													"value": 1,
+													"possibleSizes": [
+														"int8",
+														"int16",
+														"int32",
+														"int64",
+														"uint8",
+														"uint16",
+														"uint32",
+														"uint64"
+													]
+												}
+											},
+											"upper": {
+												"kind": "NumberLiteral",
+												"value": 0,
+												"possibleSizes": [
+													"int8",
+													"int16",
+													"int32",
+													"int64",
+													"uint8",
+													"uint16",
+													"uint32",
+													"uint64"
+												]
+											}
+										}
+									],
+									"inferredPossibleTypes": [
+										[
+											{
+												"kind": "TypeRange"
+											}
+										],
+										[
+											{
+												"kind": "TypeRange"
+											}
+										]
 									]
 								},
 								{
 									"kind": "VariableDeclaration",
 									"modifiers": [],
+									"mutable": true,
+									"identifiersList": [
+										{
+											"kind": "Identifier",
+											"name": "partitionedArray"
+										}
+									],
 									"declaredTypes": [],
 									"initialValues": [
 										{
@@ -448,57 +660,106 @@
 											"items": [
 												{
 													"kind": "MemberListExpression",
-													"properties": [
-														{
-															"kind": "RangeExpression",
-															"lower": {
-																"kind": "NumberLiteral",
-																"format": "int",
-																"value": 0
-															},
-															"upper": {
-																"kind": "NumberLiteral",
-																"format": "int",
-																"value": 1
-															}
-														}
-													],
 													"object": {
 														"kind": "Identifier",
 														"name": "countDown"
-													}
-												},
-												{
-													"kind": "MemberListExpression",
+													},
 													"properties": [
 														{
 															"kind": "RangeExpression",
 															"lower": {
 																"kind": "NumberLiteral",
-																"format": "int",
-																"value": 2
+																"value": 0,
+																"possibleSizes": [
+																	"int8",
+																	"int16",
+																	"int32",
+																	"int64",
+																	"uint8",
+																	"uint16",
+																	"uint32",
+																	"uint64"
+																]
 															},
 															"upper": {
 																"kind": "NumberLiteral",
-																"format": "int",
-																"value": 6
+																"value": 1,
+																"possibleSizes": [
+																	"int8",
+																	"int16",
+																	"int32",
+																	"int64",
+																	"uint8",
+																	"uint16",
+																	"uint32",
+																	"uint64"
+																]
 															}
 														}
-													],
-													"object": {
-														"kind": "Identifier",
-														"name": "countDown"
-													}
+													]
 												},
 												{
 													"kind": "MemberListExpression",
+													"object": {
+														"kind": "Identifier",
+														"name": "countDown"
+													},
 													"properties": [
 														{
 															"kind": "RangeExpression",
 															"lower": {
 																"kind": "NumberLiteral",
-																"format": "int",
-																"value": 7
+																"value": 2,
+																"possibleSizes": [
+																	"int8",
+																	"int16",
+																	"int32",
+																	"int64",
+																	"uint8",
+																	"uint16",
+																	"uint32",
+																	"uint64"
+																]
+															},
+															"upper": {
+																"kind": "NumberLiteral",
+																"value": 6,
+																"possibleSizes": [
+																	"int8",
+																	"int16",
+																	"int32",
+																	"int64",
+																	"uint8",
+																	"uint16",
+																	"uint32",
+																	"uint64"
+																]
+															}
+														}
+													]
+												},
+												{
+													"kind": "MemberListExpression",
+													"object": {
+														"kind": "Identifier",
+														"name": "countDown"
+													},
+													"properties": [
+														{
+															"kind": "RangeExpression",
+															"lower": {
+																"kind": "NumberLiteral",
+																"value": 7,
+																"possibleSizes": [
+																	"int8",
+																	"int16",
+																	"int32",
+																	"int64",
+																	"uint8",
+																	"uint16",
+																	"uint32",
+																	"uint64"
+																]
 															},
 															"upper": {
 																"kind": "UnaryExpression",
@@ -506,27 +767,24 @@
 																"operator": "-",
 																"operand": {
 																	"kind": "NumberLiteral",
-																	"format": "int",
-																	"value": 1
+																	"value": 1,
+																	"possibleSizes": [
+																		"int8",
+																		"int16",
+																		"int32",
+																		"int64"
+																	]
 																}
 															}
 														}
-													],
-													"object": {
-														"kind": "Identifier",
-														"name": "countDown"
-													}
+													]
 												}
-											]
+											],
+											"possibleTypes": []
 										}
 									],
-									"inferredTypes": [],
-									"mutable": true,
-									"identifiersList": [
-										{
-											"kind": "Identifier",
-											"name": "partitionedArray"
-										}
+									"inferredPossibleTypes": [
+										[]
 									]
 								},
 								{
@@ -534,40 +792,67 @@
 									"initializer": {
 										"kind": "VariableDeclaration",
 										"modifiers": [],
-										"declaredTypes": [],
-										"initialValues": [],
-										"inferredTypes": [],
 										"mutable": false,
 										"identifiersList": [
 											{
 												"kind": "Identifier",
 												"name": "num"
 											}
-										]
+										],
+										"declaredTypes": [],
+										"initialValues": [],
+										"inferredPossibleTypes": []
 									},
 									"iterable": {
 										"kind": "MemberListExpression",
-										"properties": [
-											{
-												"kind": "NumberLiteral",
-												"format": "int",
-												"value": 1
-											},
-											{
-												"kind": "NumberLiteral",
-												"format": "int",
-												"value": 4
-											},
-											{
-												"kind": "NumberLiteral",
-												"format": "int",
-												"value": 9
-											}
-										],
 										"object": {
 											"kind": "Identifier",
 											"name": "countDown"
-										}
+										},
+										"properties": [
+											{
+												"kind": "NumberLiteral",
+												"value": 1,
+												"possibleSizes": [
+													"int8",
+													"int16",
+													"int32",
+													"int64",
+													"uint8",
+													"uint16",
+													"uint32",
+													"uint64"
+												]
+											},
+											{
+												"kind": "NumberLiteral",
+												"value": 4,
+												"possibleSizes": [
+													"int8",
+													"int16",
+													"int32",
+													"int64",
+													"uint8",
+													"uint16",
+													"uint32",
+													"uint64"
+												]
+											},
+											{
+												"kind": "NumberLiteral",
+												"value": 9,
+												"possibleSizes": [
+													"int8",
+													"int16",
+													"int32",
+													"int64",
+													"uint8",
+													"uint16",
+													"uint32",
+													"uint64"
+												]
+											}
+										]
 									},
 									"body": {
 										"kind": "BlockStatement",
@@ -587,6 +872,13 @@
 								{
 									"kind": "VariableDeclaration",
 									"modifiers": [],
+									"mutable": true,
+									"identifiersList": [
+										{
+											"kind": "Identifier",
+											"name": "myObject"
+										}
+									],
 									"declaredTypes": [],
 									"initialValues": [
 										{
@@ -600,8 +892,17 @@
 													},
 													"value": {
 														"kind": "NumberLiteral",
-														"format": "int",
-														"value": 1
+														"value": 1,
+														"possibleSizes": [
+															"int8",
+															"int16",
+															"int32",
+															"int64",
+															"uint8",
+															"uint16",
+															"uint32",
+															"uint64"
+														]
 													}
 												},
 												{
@@ -649,52 +950,81 @@
 											]
 										}
 									],
-									"inferredTypes": [
-										{
-											"kind": "ObjectShape",
-											"properties": [
-												{
-													"kind": "PropertyShape",
-													"key": {
-														"kind": "Identifier",
-														"name": "a"
+									"inferredPossibleTypes": [
+										[
+											{
+												"kind": "ObjectShape",
+												"properties": [
+													{
+														"kind": "PropertyShape",
+														"key": {
+															"kind": "Identifier",
+															"name": "a"
+														},
+														"possibleTypes": [
+															{
+																"kind": "TypeNumber",
+																"size": "int8"
+															},
+															{
+																"kind": "TypeNumber",
+																"size": "int16"
+															},
+															{
+																"kind": "TypeNumber",
+																"size": "int32"
+															},
+															{
+																"kind": "TypeNumber",
+																"size": "int64"
+															},
+															{
+																"kind": "TypeNumber",
+																"size": "uint8"
+															},
+															{
+																"kind": "TypeNumber",
+																"size": "uint16"
+															},
+															{
+																"kind": "TypeNumber",
+																"size": "uint32"
+															},
+															{
+																"kind": "TypeNumber",
+																"size": "uint64"
+															}
+														]
 													},
-													"type": {
-														"kind": "TypePrimitive",
-														"type": "number"
-													}
-												},
-												{
-													"kind": "PropertyShape",
-													"key": {
-														"kind": "Identifier",
-														"name": "b"
+													{
+														"kind": "PropertyShape",
+														"key": {
+															"kind": "Identifier",
+															"name": "b"
+														},
+														"possibleTypes": [
+															{
+																"kind": "TypePrimitive",
+																"type": "string"
+															}
+														]
 													},
-													"type": {
-														"kind": "TypePrimitive",
-														"type": "string"
+													{
+														"kind": "PropertyShape",
+														"key": {
+															"kind": "Identifier",
+															"name": "c"
+														},
+														"possibleTypes": [
+															{
+																"kind": "TypePrimitive",
+																"type": "bool"
+															}
+														]
 													}
-												},
-												{
-													"kind": "PropertyShape",
-													"key": {
-														"kind": "Identifier",
-														"name": "c"
-													},
-													"type": {
-														"kind": "TypePrimitive",
-														"type": "bool"
-													}
-												}
-											]
-										}
-									],
-									"mutable": true,
-									"identifiersList": [
-										{
-											"kind": "Identifier",
-											"name": "myObject"
-										}
+												]
+											}
+										]
 									]
 								},
 								{
@@ -714,18 +1044,6 @@
 								{
 									"kind": "VariableDeclaration",
 									"modifiers": [],
-									"declaredTypes": [],
-									"initialValues": [
-										{
-											"kind": "CallExpression",
-											"callee": {
-												"kind": "Identifier",
-												"name": "methodThatReturnsBool?"
-											},
-											"args": []
-										}
-									],
-									"inferredTypes": [],
 									"mutable": false,
 									"identifiersList": [
 										{
@@ -740,11 +1058,32 @@
 											"kind": "Identifier",
 											"name": "myThing"
 										}
+									],
+									"declaredTypes": [],
+									"initialValues": [
+										{
+											"kind": "CallExpression",
+											"callee": {
+												"kind": "Identifier",
+												"name": "methodThatReturnsBool?"
+											},
+											"args": []
+										}
+									],
+									"inferredPossibleTypes": [
+										[]
 									]
 								},
 								{
 									"kind": "VariableDeclaration",
 									"modifiers": [],
+									"mutable": false,
+									"identifiersList": [
+										{
+											"kind": "Identifier",
+											"name": "myTuple"
+										}
+									],
 									"declaredTypes": [],
 									"initialValues": [
 										{
@@ -752,8 +1091,17 @@
 											"items": [
 												{
 													"kind": "NumberLiteral",
-													"format": "int",
-													"value": 1
+													"value": 1,
+													"possibleSizes": [
+														"int8",
+														"int16",
+														"int32",
+														"int64",
+														"uint8",
+														"uint16",
+														"uint32",
+														"uint64"
+													]
 												},
 												{
 													"kind": "BoolLiteral",
@@ -772,44 +1120,86 @@
 											]
 										}
 									],
-									"inferredTypes": [
-										{
-											"kind": "TupleShape",
-											"types": [
-												{
-													"kind": "TypePrimitive",
-													"type": "number"
-												},
-												{
-													"kind": "TypePrimitive",
-													"type": "bool"
-												},
-												{
-													"kind": "TypePrimitive",
-													"type": "string"
-												},
-												{
-													"kind": "TypePrimitive",
-													"type": "path"
-												}
-											]
-										}
-									],
-									"mutable": false,
-									"identifiersList": [
-										{
-											"kind": "Identifier",
-											"name": "myTuple"
-										}
+									"inferredPossibleTypes": [
+										[
+											{
+												"kind": "TupleShape",
+												"possibleTypes": [
+													[
+														{
+															"kind": "TypeNumber",
+															"size": "int8"
+														},
+														{
+															"kind": "TypeNumber",
+															"size": "int16"
+														},
+														{
+															"kind": "TypeNumber",
+															"size": "int32"
+														},
+														{
+															"kind": "TypeNumber",
+															"size": "int64"
+														},
+														{
+															"kind": "TypeNumber",
+															"size": "uint8"
+														},
+														{
+															"kind": "TypeNumber",
+															"size": "uint16"
+														},
+														{
+															"kind": "TypeNumber",
+															"size": "uint32"
+														},
+														{
+															"kind": "TypeNumber",
+															"size": "uint64"
+														}
+													],
+													[
+														{
+															"kind": "TypePrimitive",
+															"type": "bool"
+														}
+													],
+													[
+														{
+															"kind": "TypePrimitive",
+															"type": "string"
+														}
+													],
+													[
+														{
+															"kind": "TypePrimitive",
+															"type": "path"
+														}
+													]
+												]
+											}
+										]
 									]
 								},
 								{
 									"kind": "VariableDeclaration",
 									"modifiers": [],
+									"mutable": true,
+									"identifiersList": [
+										{
+											"kind": "Identifier",
+											"name": "partialObj"
+										}
+									],
 									"declaredTypes": [],
 									"initialValues": [
 										{
 											"kind": "MemberListExpression",
+											"object": {
+												"kind": "Identifier",
+												"name": "myObject"
+											},
 											"properties": [
 												{
 													"kind": "Identifier",
@@ -819,40 +1209,31 @@
 													"kind": "Identifier",
 													"name": "d"
 												}
-											],
-											"object": {
-												"kind": "Identifier",
-												"name": "myObject"
-											}
+											]
 										}
 									],
-									"inferredTypes": [],
-									"mutable": true,
-									"identifiersList": [
-										{
-											"kind": "Identifier",
-											"name": "partialObj"
-										}
+									"inferredPossibleTypes": [
+										[]
 									]
 								},
 								{
 									"kind": "VariableDeclaration",
 									"modifiers": [],
-									"declaredTypes": [
-										{
-											"kind": "TypePrimitive",
-											"type": "number"
-										}
-									],
-									"initialValues": [],
-									"inferredTypes": [],
 									"mutable": true,
 									"identifiersList": [
 										{
 											"kind": "Identifier",
 											"name": "initializeAndAssignLater"
 										}
-									]
+									],
+									"declaredTypes": [
+										{
+											"kind": "TypeNumber",
+											"size": "int32"
+										}
+									],
+									"initialValues": [],
+									"inferredPossibleTypes": []
 								},
 								{
 									"kind": "AssignmentExpression",
@@ -865,8 +1246,17 @@
 									"right": [
 										{
 											"kind": "NumberLiteral",
-											"format": "int",
-											"value": 5
+											"value": 5,
+											"possibleSizes": [
+												"int8",
+												"int16",
+												"int32",
+												"int64",
+												"uint8",
+												"uint16",
+												"uint32",
+												"uint64"
+											]
 										}
 									]
 								},
@@ -880,14 +1270,14 @@
 									]
 								}
 							]
-						},
-						"joeDoc": {
-							"kind": "JoeDoc",
-							"content": "/** method with no args */"
 						}
 					},
 					{
 						"kind": "FunctionDeclaration",
+						"joeDoc": {
+							"kind": "JoeDoc",
+							"content": "/** with args */"
+						},
 						"modifiers": [],
 						"name": {
 							"kind": "Identifier",
@@ -906,7 +1296,8 @@
 								"declaredType": {
 									"kind": "TypePrimitive",
 									"type": "bool"
-								}
+								},
+								"inferredPossibleTypes": []
 							},
 							{
 								"kind": "Parameter",
@@ -919,7 +1310,8 @@
 								"declaredType": {
 									"kind": "Identifier",
 									"name": "Tuple"
-								}
+								},
+								"inferredPossibleTypes": []
 							},
 							{
 								"kind": "Parameter",
@@ -929,13 +1321,15 @@
 									"kind": "Identifier",
 									"name": "arg3"
 								},
+								"inferredPossibleTypes": [
+									{
+										"kind": "TypePrimitive",
+										"type": "bool"
+									}
+								],
 								"defaultValue": {
 									"kind": "BoolLiteral",
 									"value": true
-								},
-								"inferredType": {
-									"kind": "TypePrimitive",
-									"type": "bool"
 								}
 							},
 							{
@@ -952,21 +1346,22 @@
 										"kind": "Identifier",
 										"name": "Thing"
 									}
-								}
+								},
+								"inferredPossibleTypes": []
 							}
 						],
 						"returnTypes": [],
 						"body": {
 							"kind": "BlockStatement",
 							"expressions": []
-						},
-						"joeDoc": {
-							"kind": "JoeDoc",
-							"content": "/** with args */"
 						}
 					},
 					{
 						"kind": "FunctionDeclaration",
+						"joeDoc": {
+							"kind": "JoeDoc",
+							"content": "/** with one return val */"
+						},
 						"modifiers": [],
 						"name": {
 							"kind": "Identifier",
@@ -993,14 +1388,14 @@
 									]
 								}
 							]
-						},
-						"joeDoc": {
-							"kind": "JoeDoc",
-							"content": "/** with one return val */"
 						}
 					},
 					{
 						"kind": "FunctionDeclaration",
+						"joeDoc": {
+							"kind": "JoeDoc",
+							"content": "/** multiple return vals */"
+						},
 						"modifiers": [],
 						"name": {
 							"kind": "Identifier",
@@ -1014,8 +1409,8 @@
 								"type": "bool"
 							},
 							{
-								"kind": "TypePrimitive",
-								"type": "number"
+								"kind": "TypeNumber",
+								"size": "dec32"
 							},
 							{
 								"kind": "Identifier",
@@ -1034,8 +1429,11 @@
 										},
 										{
 											"kind": "NumberLiteral",
-											"format": "int",
-											"value": 5
+											"value": 5,
+											"possibleSizes": [
+												"dec32",
+												"dec64"
+											]
 										},
 										{
 											"kind": "CallExpression",
@@ -1055,10 +1453,6 @@
 									]
 								}
 							]
-						},
-						"joeDoc": {
-							"kind": "JoeDoc",
-							"content": "/** multiple return vals */"
 						}
 					}
 				]

--- a/examples/example1/main.joe
+++ b/examples/example1/main.joe
@@ -17,7 +17,7 @@ class Foo<|A|> extends Bar<|A|>, Baz implements AbstractFooBar<|A|>, AnotherAbst
 	const isDone? = true; // const
 
 	/** method with no args */
-	f foo -> number {
+	f foo -> uint64 {
 		const size = when someNumber {
 			1, 2 -> 'small',
 			3 .. 10 -> 'medium',
@@ -60,7 +60,7 @@ class Foo<|A|> extends Bar<|A|>, Baz implements AbstractFooBar<|A|>, AnotherAbst
 
 		let partialObj = myObject[a, d]; // new object {a: 1, d: 'foo'}
 
-		let initializeAndAssignLater: number;
+		let initializeAndAssignLater: int32;
 		initializeAndAssignLater = 5;
 
 		return initializeAndAssignLater;
@@ -75,7 +75,7 @@ class Foo<|A|> extends Bar<|A|>, Baz implements AbstractFooBar<|A|>, AnotherAbst
 	}
 
 	/** multiple return vals */
-	f methodThatReturnsBool? -> bool, number, Thing {
-		return false, 5, Thing.create();
+	f methodThatReturnsBool? -> bool, dec32, Thing {
+		return false, 5.0, Thing.create();
 	}
 }

--- a/examples/example1/main.parse-tree
+++ b/examples/example1/main.parse-tree
@@ -212,7 +212,7 @@
                   [
                     'FunctionReturns',
                     [
-                      [ 'Type', 'number' ]
+                      [ 'Type', 'uint64' ]
                     ]
                   ],
                   [
@@ -792,7 +792,7 @@
                           [
                             'TypeArgumentsList',
                             [
-                              [ 'Type', 'number' ]
+                              [ 'Type', 'int32' ]
                             ]
                           ]
                         ]
@@ -925,7 +925,7 @@
                     [
                       [ 'Type', 'bool' ],
                       [ 'CommaSeparator' ],
-                      [ 'Type', 'number' ],
+                      [ 'Type', 'dec32' ],
                       [ 'CommaSeparator' ],
                       [ 'Identifier', 'Thing' ]
                     ]
@@ -938,7 +938,7 @@
                         [
                           [ 'BoolLiteral', 'false' ],
                           [ 'CommaSeparator' ],
-                          [ 'NumberLiteral', '5' ],
+                          [ 'NumberLiteral', '5.0' ],
                           [ 'CommaSeparator' ],
                           [
                             'CallExpression',

--- a/examples/example1/main.tokens
+++ b/examples/example1/main.tokens
@@ -563,7 +563,7 @@
 		"type": "type",
 		"start": 477,
 		"end": 483,
-		"value": "number",
+		"value": "uint64",
 		"line": 20,
 		"col": 11
 	},
@@ -2018,480 +2018,480 @@
 	{
 		"type": "type",
 		"start": 1499,
-		"end": 1505,
-		"value": "number",
+		"end": 1504,
+		"value": "int32",
 		"line": 63,
 		"col": 33
 	},
 	{
 		"type": "semicolon",
-		"start": 1505,
-		"end": 1506,
+		"start": 1504,
+		"end": 1505,
 		"value": ";",
 		"line": 63,
-		"col": 39
+		"col": 38
 	},
 	{
 		"type": "identifier",
-		"start": 1509,
-		"end": 1533,
+		"start": 1508,
+		"end": 1532,
 		"value": "initializeAndAssignLater",
 		"line": 64,
 		"col": 3
 	},
 	{
 		"type": "assign",
-		"start": 1534,
-		"end": 1535,
+		"start": 1533,
+		"end": 1534,
 		"value": "=",
 		"line": 64,
 		"col": 28
 	},
 	{
 		"type": "number",
-		"start": 1536,
-		"end": 1537,
+		"start": 1535,
+		"end": 1536,
 		"value": "5",
 		"line": 64,
 		"col": 30
 	},
 	{
 		"type": "semicolon",
-		"start": 1537,
-		"end": 1538,
+		"start": 1536,
+		"end": 1537,
 		"value": ";",
 		"line": 64,
 		"col": 31
 	},
 	{
 		"type": "keyword",
-		"start": 1542,
-		"end": 1548,
+		"start": 1541,
+		"end": 1547,
 		"value": "return",
 		"line": 66,
 		"col": 3
 	},
 	{
 		"type": "identifier",
-		"start": 1549,
-		"end": 1573,
+		"start": 1548,
+		"end": 1572,
 		"value": "initializeAndAssignLater",
 		"line": 66,
 		"col": 10
 	},
 	{
 		"type": "semicolon",
-		"start": 1573,
-		"end": 1574,
+		"start": 1572,
+		"end": 1573,
 		"value": ";",
 		"line": 66,
 		"col": 34
 	},
 	{
 		"type": "brace_close",
-		"start": 1576,
-		"end": 1577,
+		"start": 1575,
+		"end": 1576,
 		"value": "}",
 		"line": 67,
 		"col": 2
 	},
 	{
 		"type": "comment",
-		"start": 1580,
-		"end": 1596,
+		"start": 1579,
+		"end": 1595,
 		"value": "/** with args */",
 		"line": 69,
 		"col": 2
 	},
 	{
 		"type": "keyword",
-		"start": 1598,
-		"end": 1599,
+		"start": 1597,
+		"end": 1598,
 		"value": "f",
 		"line": 70,
 		"col": 2
 	},
 	{
 		"type": "identifier",
-		"start": 1600,
-		"end": 1614,
+		"start": 1599,
+		"end": 1613,
 		"value": "methodWithArgs",
 		"line": 70,
 		"col": 4
 	},
 	{
 		"type": "paren_open",
-		"start": 1615,
-		"end": 1616,
+		"start": 1614,
+		"end": 1615,
 		"value": "(",
 		"line": 70,
 		"col": 19
 	},
 	{
 		"type": "identifier",
-		"start": 1616,
-		"end": 1620,
+		"start": 1615,
+		"end": 1619,
 		"value": "arg1",
 		"line": 70,
 		"col": 20
 	},
 	{
 		"type": "colon",
-		"start": 1620,
-		"end": 1621,
+		"start": 1619,
+		"end": 1620,
 		"value": ":",
 		"line": 70,
 		"col": 24
 	},
 	{
 		"type": "type",
-		"start": 1622,
-		"end": 1626,
+		"start": 1621,
+		"end": 1625,
 		"value": "bool",
 		"line": 70,
 		"col": 26
 	},
 	{
 		"type": "comma",
-		"start": 1626,
-		"end": 1627,
+		"start": 1625,
+		"end": 1626,
 		"value": ",",
 		"line": 70,
 		"col": 30
 	},
 	{
 		"type": "identifier",
-		"start": 1628,
-		"end": 1632,
+		"start": 1627,
+		"end": 1631,
 		"value": "arg2",
 		"line": 70,
 		"col": 32
 	},
 	{
 		"type": "colon",
-		"start": 1632,
-		"end": 1633,
+		"start": 1631,
+		"end": 1632,
 		"value": ":",
 		"line": 70,
 		"col": 36
 	},
 	{
 		"type": "identifier",
-		"start": 1634,
-		"end": 1639,
+		"start": 1633,
+		"end": 1638,
 		"value": "Tuple",
 		"line": 70,
 		"col": 38
 	},
 	{
 		"type": "comma",
-		"start": 1639,
-		"end": 1640,
+		"start": 1638,
+		"end": 1639,
 		"value": ",",
 		"line": 70,
 		"col": 43
 	},
 	{
 		"type": "identifier",
-		"start": 1641,
-		"end": 1645,
+		"start": 1640,
+		"end": 1644,
 		"value": "arg3",
 		"line": 70,
 		"col": 45
 	},
 	{
 		"type": "assign",
-		"start": 1646,
-		"end": 1647,
+		"start": 1645,
+		"end": 1646,
 		"value": "=",
 		"line": 70,
 		"col": 50
 	},
 	{
 		"type": "bool",
-		"start": 1648,
-		"end": 1652,
+		"start": 1647,
+		"end": 1651,
 		"value": "true",
 		"line": 70,
 		"col": 52
 	},
 	{
 		"type": "comma",
-		"start": 1652,
-		"end": 1653,
+		"start": 1651,
+		"end": 1652,
 		"value": ",",
 		"line": 70,
 		"col": 56
 	},
 	{
 		"type": "dotdotdot",
-		"start": 1654,
-		"end": 1657,
+		"start": 1653,
+		"end": 1656,
 		"value": "...",
 		"line": 70,
 		"col": 58
 	},
 	{
 		"type": "identifier",
-		"start": 1657,
-		"end": 1667,
+		"start": 1656,
+		"end": 1666,
 		"value": "otherStuff",
 		"line": 70,
 		"col": 61
 	},
 	{
 		"type": "colon",
-		"start": 1667,
-		"end": 1668,
+		"start": 1666,
+		"end": 1667,
 		"value": ":",
 		"line": 70,
 		"col": 71
 	},
 	{
 		"type": "identifier",
-		"start": 1669,
-		"end": 1674,
+		"start": 1668,
+		"end": 1673,
 		"value": "Thing",
 		"line": 70,
 		"col": 73
 	},
 	{
 		"type": "bracket_open",
-		"start": 1674,
-		"end": 1675,
+		"start": 1673,
+		"end": 1674,
 		"value": "[",
 		"line": 70,
 		"col": 78
 	},
 	{
 		"type": "bracket_close",
-		"start": 1675,
-		"end": 1676,
+		"start": 1674,
+		"end": 1675,
 		"value": "]",
 		"line": 70,
 		"col": 79
 	},
 	{
 		"type": "paren_close",
-		"start": 1676,
-		"end": 1677,
+		"start": 1675,
+		"end": 1676,
 		"value": ")",
 		"line": 70,
 		"col": 80
 	},
 	{
 		"type": "brace_open",
-		"start": 1678,
-		"end": 1679,
+		"start": 1677,
+		"end": 1678,
 		"value": "{",
 		"line": 70,
 		"col": 82
 	},
 	{
 		"type": "comment",
-		"start": 1680,
-		"end": 1689,
+		"start": 1679,
+		"end": 1688,
 		"value": "/* ... */",
 		"line": 70,
 		"col": 84
 	},
 	{
 		"type": "brace_close",
-		"start": 1690,
-		"end": 1691,
+		"start": 1689,
+		"end": 1690,
 		"value": "}",
 		"line": 70,
 		"col": 94
 	},
 	{
 		"type": "comment",
-		"start": 1694,
-		"end": 1720,
+		"start": 1693,
+		"end": 1719,
 		"value": "/** with one return val */",
 		"line": 72,
 		"col": 2
 	},
 	{
 		"type": "keyword",
-		"start": 1722,
-		"end": 1723,
+		"start": 1721,
+		"end": 1722,
 		"value": "f",
 		"line": 73,
 		"col": 2
 	},
 	{
 		"type": "identifier",
-		"start": 1724,
-		"end": 1746,
+		"start": 1723,
+		"end": 1745,
 		"value": "methodThatReturnsBool?",
 		"line": 73,
 		"col": 4
 	},
 	{
 		"type": "right_arrow",
-		"start": 1747,
-		"end": 1749,
+		"start": 1746,
+		"end": 1748,
 		"value": "->",
 		"line": 73,
 		"col": 27
 	},
 	{
 		"type": "type",
-		"start": 1750,
-		"end": 1754,
+		"start": 1749,
+		"end": 1753,
 		"value": "bool",
 		"line": 73,
 		"col": 30
 	},
 	{
 		"type": "brace_open",
-		"start": 1755,
-		"end": 1756,
+		"start": 1754,
+		"end": 1755,
 		"value": "{",
 		"line": 73,
 		"col": 35
 	},
 	{
 		"type": "keyword",
-		"start": 1759,
-		"end": 1765,
+		"start": 1758,
+		"end": 1764,
 		"value": "return",
 		"line": 74,
 		"col": 3
 	},
 	{
 		"type": "bool",
-		"start": 1766,
-		"end": 1770,
+		"start": 1765,
+		"end": 1769,
 		"value": "true",
 		"line": 74,
 		"col": 10
 	},
 	{
 		"type": "semicolon",
-		"start": 1770,
-		"end": 1771,
+		"start": 1769,
+		"end": 1770,
 		"value": ";",
 		"line": 74,
 		"col": 14
 	},
 	{
 		"type": "brace_close",
-		"start": 1773,
-		"end": 1774,
+		"start": 1772,
+		"end": 1773,
 		"value": "}",
 		"line": 75,
 		"col": 2
 	},
 	{
 		"type": "comment",
-		"start": 1777,
-		"end": 1804,
+		"start": 1776,
+		"end": 1803,
 		"value": "/** multiple return vals */",
 		"line": 77,
 		"col": 2
 	},
 	{
 		"type": "keyword",
-		"start": 1806,
-		"end": 1807,
+		"start": 1805,
+		"end": 1806,
 		"value": "f",
 		"line": 78,
 		"col": 2
 	},
 	{
 		"type": "identifier",
-		"start": 1808,
-		"end": 1830,
+		"start": 1807,
+		"end": 1829,
 		"value": "methodThatReturnsBool?",
 		"line": 78,
 		"col": 4
 	},
 	{
 		"type": "right_arrow",
-		"start": 1831,
-		"end": 1833,
+		"start": 1830,
+		"end": 1832,
 		"value": "->",
 		"line": 78,
 		"col": 27
 	},
 	{
 		"type": "type",
-		"start": 1834,
-		"end": 1838,
+		"start": 1833,
+		"end": 1837,
 		"value": "bool",
 		"line": 78,
 		"col": 30
 	},
 	{
 		"type": "comma",
-		"start": 1838,
-		"end": 1839,
+		"start": 1837,
+		"end": 1838,
 		"value": ",",
 		"line": 78,
 		"col": 34
 	},
 	{
 		"type": "type",
-		"start": 1840,
-		"end": 1846,
-		"value": "number",
+		"start": 1839,
+		"end": 1844,
+		"value": "dec32",
 		"line": 78,
 		"col": 36
 	},
 	{
 		"type": "comma",
-		"start": 1846,
-		"end": 1847,
+		"start": 1844,
+		"end": 1845,
 		"value": ",",
 		"line": 78,
-		"col": 42
+		"col": 41
 	},
 	{
 		"type": "identifier",
-		"start": 1848,
-		"end": 1853,
+		"start": 1846,
+		"end": 1851,
 		"value": "Thing",
 		"line": 78,
-		"col": 44
+		"col": 43
 	},
 	{
 		"type": "brace_open",
-		"start": 1854,
-		"end": 1855,
+		"start": 1852,
+		"end": 1853,
 		"value": "{",
 		"line": 78,
-		"col": 50
+		"col": 49
 	},
 	{
 		"type": "keyword",
-		"start": 1858,
-		"end": 1864,
+		"start": 1856,
+		"end": 1862,
 		"value": "return",
 		"line": 79,
 		"col": 3
 	},
 	{
 		"type": "bool",
-		"start": 1865,
-		"end": 1870,
+		"start": 1863,
+		"end": 1868,
 		"value": "false",
 		"line": 79,
 		"col": 10
 	},
 	{
 		"type": "comma",
-		"start": 1870,
-		"end": 1871,
+		"start": 1868,
+		"end": 1869,
 		"value": ",",
 		"line": 79,
 		"col": 15
 	},
 	{
 		"type": "number",
-		"start": 1872,
+		"start": 1870,
 		"end": 1873,
-		"value": "5",
+		"value": "5.0",
 		"line": 79,
 		"col": 17
 	},
@@ -2501,7 +2501,7 @@
 		"end": 1874,
 		"value": ",",
 		"line": 79,
-		"col": 18
+		"col": 20
 	},
 	{
 		"type": "identifier",
@@ -2509,7 +2509,7 @@
 		"end": 1880,
 		"value": "Thing",
 		"line": 79,
-		"col": 20
+		"col": 22
 	},
 	{
 		"type": "dot",
@@ -2517,7 +2517,7 @@
 		"end": 1881,
 		"value": ".",
 		"line": 79,
-		"col": 25
+		"col": 27
 	},
 	{
 		"type": "identifier",
@@ -2525,7 +2525,7 @@
 		"end": 1887,
 		"value": "create",
 		"line": 79,
-		"col": 26
+		"col": 28
 	},
 	{
 		"type": "paren_open",
@@ -2533,7 +2533,7 @@
 		"end": 1888,
 		"value": "(",
 		"line": 79,
-		"col": 32
+		"col": 34
 	},
 	{
 		"type": "paren_close",
@@ -2541,7 +2541,7 @@
 		"end": 1889,
 		"value": ")",
 		"line": 79,
-		"col": 33
+		"col": 35
 	},
 	{
 		"type": "semicolon",
@@ -2549,7 +2549,7 @@
 		"end": 1890,
 		"value": ";",
 		"line": 79,
-		"col": 34
+		"col": 36
 	},
 	{
 		"type": "brace_close",

--- a/lexer/types.ts
+++ b/lexer/types.ts
@@ -1,3 +1,5 @@
+import { numberSizesAll } from '../shared/numbers/sizes';
+
 // token types
 export const tokenTypesUsingSymbols = {
 	and: '&&',
@@ -43,8 +45,23 @@ export const tokenTypesUsingSymbols = {
 	triangle_close: '|>',
 };
 
-export const primitiveTypes = ['bool', 'number', 'path', 'regex', 'string'] as const;
+// Primitive Types
+
+// Most types are both delcaraable and will be the type of the value.
+// However, 'number' is different in that it itself is not declarable
+// since you cannot do `let x: number = 5`, but you must use one of
+// the number sizes, like `let x: int8 = 5`.
+//
+// However, the type of the value is still 'number', so we need to
+// include it in the list of "otherTokenTypes". This holds true
+// even if the size is specified, like `let x = 5_int8`. The
+// parser will take care of converting the value to the size.
+
+export const primitiveTypes = ['bool', 'path', 'regex', 'string'] as const;
 export type PrimitiveType = (typeof primitiveTypes)[number];
+
+// declarable types
+export const declarableTypes = ['bool', ...numberSizesAll, 'path', 'range', 'regex', 'string'] as const;
 
 const otherTokenTypes = [
 	'bool',
@@ -52,7 +69,7 @@ const otherTokenTypes = [
 	'eof',
 	'identifier',
 	'keyword',
-	'number',
+	'number', // this is considered an "other" type because it is not declarable, but it is the type of the value
 	'path',
 	'regex',
 	'string',
@@ -107,9 +124,6 @@ export const keywords = [
 	'when',
 ] as const;
 
-// types
-export const types = ['bool', 'number', 'path', 'range', 'regex', 'string'] as const;
-
 // special Values
 const specialValues = ['true', 'false'] as const;
 type SpecialValue = (typeof specialValues)[number];
@@ -149,6 +163,7 @@ export const patterns = {
 	DIGITS: /[0-9]/,
 	LETTERS: /[a-z]/i,
 	NEWLINE: /\n/,
+	NUMBER_TYPE_SUFFIXES: new RegExp(`_(${numberSizesAll.join('|')})`),
 	PATH: /[a-zA-Z0-9-_./]/, // characters in path, excluding the front: @ or .
 	// eslint-disable-next-line no-control-regex
 	UNICODE: /[^\x00-\x7F]/, // characters above ASCII and in the Unicode standard, see https://stackoverflow.com/a/72733569

--- a/parser/node.ts
+++ b/parser/node.ts
@@ -40,11 +40,7 @@ export function ChangeNodeType(node: Node, newType: NT): void {
  * @param parent - The parent Node
  * @returns A UnaryExpression Node
  */
-export function MakeUnaryExpressionNode(
-	token: Token,
-	before: boolean,
-	parent: Node,
-): UnaryExpressionNode {
+export function MakeUnaryExpressionNode(token: Token, before: boolean, parent: Node): UnaryExpressionNode {
 	const node: UnaryExpressionNode = {
 		type: NT.UnaryExpression,
 		value: token.value,

--- a/parser/parser.ts
+++ b/parser/parser.ts
@@ -113,8 +113,7 @@ export default class Parser {
 	public parse(): Result<Node> {
 		do {
 			// before going on to the next token, update this.prevToken
-			this.prevToken =
-				this.currentToken.outcome === 'ok' ? this.currentToken.value : undefined;
+			this.prevToken = this.currentToken.outcome === 'ok' ? this.currentToken.value : undefined;
 
 			// get the next token
 			this.currentToken = this.getNextToken();
@@ -140,9 +139,7 @@ export default class Parser {
 							this.currentRoot.type === NT.FunctionDeclaration ||
 							this.currentRoot.type === NT.FunctionSignature
 						) {
-							this.beginExpressionWith(
-								MakeNode(NT.ParametersList, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.ParametersList, token, this.currentRoot, true));
 
 							// next case:
 							// the only way this could be a CallExpression is if the previous token was an identifier or close of generic type list
@@ -162,13 +159,9 @@ export default class Parser {
 								return result;
 							}
 
-							this.beginExpressionWith(
-								MakeNode(NT.ArgumentsList, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.ArgumentsList, token, this.currentRoot, true));
 						} else {
-							this.beginExpressionWith(
-								MakeNode(NT.Parenthesized, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.Parenthesized, token, this.currentRoot, true));
 						}
 						break;
 					case NT.MemberExpression:
@@ -178,10 +171,7 @@ export default class Parser {
 						// is that left-hand side rather than the operator. And we cannot check whether we're _in_ a BinaryExpression since
 						// we could legitimately could be in a CallExpression on the right-hand side, i.e. `a.b && (c)` and `a.b && c()` both
 						// have the same previous Node and the same currentRoot.
-						if (
-							this.prevToken?.type &&
-							['identifier', 'triangle_close'].includes(this.prevToken.type)
-						) {
+						if (this.prevToken?.type && ['identifier', 'triangle_close'].includes(this.prevToken.type)) {
 							const result = this.beginExpressionWithAdoptingPreviousNode(
 								MakeNode(NT.CallExpression, token, this.currentRoot, true),
 							);
@@ -189,13 +179,9 @@ export default class Parser {
 								return result;
 							}
 
-							this.beginExpressionWith(
-								MakeNode(NT.ArgumentsList, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.ArgumentsList, token, this.currentRoot, true));
 						} else {
-							this.beginExpressionWith(
-								MakeNode(NT.Parenthesized, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.Parenthesized, token, this.currentRoot, true));
 						}
 						break;
 					case NT.TypeArgumentsList:
@@ -204,38 +190,21 @@ export default class Parser {
 
 							if (
 								twoBackType &&
-								(
-									[NT.Identifier, NT.MemberExpression, NT.ThisKeyword] as NT[]
-								).includes(twoBackType)
+								([NT.Identifier, NT.MemberExpression, NT.ThisKeyword] as NT[]).includes(twoBackType)
 							) {
 								// we're in a CallExpression after the GenericTypesList
-								const callExpressionNode = MakeNode(
-									NT.CallExpression,
-									token,
-									this.currentRoot,
-									true,
-								);
-								let wasAdopted = this.adoptNode(
-									this.currentRoot,
-									twoBack,
-									callExpressionNode,
-								);
+								const callExpressionNode = MakeNode(NT.CallExpression, token, this.currentRoot, true);
+								let wasAdopted = this.adoptNode(this.currentRoot, twoBack, callExpressionNode);
 								if (wasAdopted.outcome === 'error') {
 									return error(wasAdopted.error);
 								}
 
-								wasAdopted = this.adoptNode(
-									this.currentRoot,
-									prev,
-									callExpressionNode,
-								);
+								wasAdopted = this.adoptNode(this.currentRoot, prev, callExpressionNode);
 								this.beginExpressionWith(callExpressionNode);
 							}
 
 							// begin the ArgumentsList
-							this.beginExpressionWith(
-								MakeNode(NT.ArgumentsList, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.ArgumentsList, token, this.currentRoot, true));
 						}
 						break;
 					case NT.TypeParametersList:
@@ -244,9 +213,7 @@ export default class Parser {
 							this.currentRoot.type === NT.FunctionSignature
 						) {
 							// we're in a FunctionDeclaration after the GenericTypesList
-							this.beginExpressionWith(
-								MakeNode(NT.ParametersList, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.ParametersList, token, this.currentRoot, true));
 						}
 						break;
 					default:
@@ -256,13 +223,9 @@ export default class Parser {
 						) {
 							// we're in an anonymous FunctionDeclaration after the `f` keyword
 							// and there is no previous node
-							this.beginExpressionWith(
-								MakeNode(NT.ParametersList, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.ParametersList, token, this.currentRoot, true));
 						} else {
-							this.beginExpressionWith(
-								MakeNode(NT.Parenthesized, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.Parenthesized, token, this.currentRoot, true));
 						}
 						break;
 				}
@@ -287,7 +250,7 @@ export default class Parser {
 				this.endExpressionIfIn(NT.CallExpression);
 
 				// check if we're in a FunctionReturns, if so, it's finished
-				// eg `f foo (bar: number, callback: f -> bool)`
+				// eg `f foo (bar: int64, callback: f -> bool)`
 				this.endExpressionIfIn(NT.FunctionReturns);
 
 				// check if we're in a FunctionSignature, if so, it's finished
@@ -327,34 +290,25 @@ export default class Parser {
 					NT.TypeArgumentsList,
 				];
 				const nodeTypesThatParentAnObjectExpression: NT[] = [NT.AssignablesList];
-				const nodeTypesThatParentAnObjectShape: NT[] = [
-					NT.ArgumentsList,
-					NT.TypeArgumentsList,
-				];
+				const nodeTypesThatParentAnObjectShape: NT[] = [NT.ArgumentsList, NT.TypeArgumentsList];
 				if (nodeTypesThatParentAnObjectShape.includes(this.currentRoot.type)) {
 					if (this.debug) {
 						console.debug('Beginning an ObjectShape');
 					}
 
-					this.beginExpressionWith(
-						MakeNode(NT.ObjectShape, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.ObjectShape, token, this.currentRoot, true));
 				} else if (nodeTypesThatParentAnObjectExpression.includes(this.currentRoot.type)) {
 					if (this.debug) {
 						console.debug('Beginning an ObjectExpression');
 					}
 
-					this.beginExpressionWith(
-						MakeNode(NT.ObjectExpression, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.ObjectExpression, token, this.currentRoot, true));
 				} else if (typeof prevType === 'undefined') {
 					if (this.debug) {
 						console.debug('Beginning a BlockStatement');
 					}
 
-					this.beginExpressionWith(
-						MakeNode(NT.BlockStatement, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.BlockStatement, token, this.currentRoot, true));
 				} else if (
 					nodeTypesThatPrecedeAnObjectExpression.includes(prevType) ||
 					(this.currentRoot.type === NT.Property && prevType === NT.Identifier)
@@ -363,17 +317,13 @@ export default class Parser {
 						console.debug('Beginning an ObjectExpression');
 					}
 
-					this.beginExpressionWith(
-						MakeNode(NT.ObjectExpression, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.ObjectExpression, token, this.currentRoot, true));
 				} else {
 					if (this.debug) {
 						console.debug('Beginning a BlockStatement');
 					}
 
-					this.beginExpressionWith(
-						MakeNode(NT.BlockStatement, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.BlockStatement, token, this.currentRoot, true));
 				}
 			} else if (token.type === 'brace_close') {
 				this.endExpression();
@@ -387,26 +337,15 @@ export default class Parser {
 				this.endExpressionIfIn(NT.ObjectExpression);
 				this.endExpressionIfIn(NT.ObjectShape);
 			} else if (token.type === 'bracket_open') {
-				const isNextABracketClose =
-					this.lexer.peek(0) === tokenTypesUsingSymbols.bracket_close;
+				const isNextABracketClose = this.lexer.peek(0) === tokenTypesUsingSymbols.bracket_close;
 				const [, prevType] = this.prev();
 
 				if (typeof prevType === 'undefined') {
-					this.beginExpressionWith(
-						MakeNode(NT.ArrayExpression, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.ArrayExpression, token, this.currentRoot, true));
 				} else {
 					if (
 						isNextABracketClose &&
-						(
-							[
-								NT.ArrayOf,
-								NT.Identifier,
-								NT.ObjectShape,
-								NT.TupleShape,
-								NT.Type,
-							] as NT[]
-						).includes(prevType)
+						([NT.ArrayOf, NT.Identifier, NT.ObjectShape, NT.TupleShape, NT.Type] as NT[]).includes(prevType)
 					) {
 						// TODO or member chain
 						// we have an array type
@@ -434,13 +373,9 @@ export default class Parser {
 							return result;
 						}
 
-						this.beginExpressionWith(
-							MakeNode(NT.MemberList, token, this.currentRoot, true),
-						);
+						this.beginExpressionWith(MakeNode(NT.MemberList, token, this.currentRoot, true));
 					} else {
-						this.beginExpressionWith(
-							MakeNode(NT.ArrayExpression, token, this.currentRoot, true),
-						);
+						this.beginExpressionWith(MakeNode(NT.ArrayExpression, token, this.currentRoot, true));
 					}
 				}
 			} else if (token.type === 'bracket_close') {
@@ -558,9 +493,7 @@ export default class Parser {
 
 				if (this.debug) {
 					console.debug(
-						`Creating a NumberLiteral Node in ${this.lineage(this.currentRoot)} for "${
-							token.value
-						}"`,
+						`Creating a NumberLiteral Node in ${this.lineage(this.currentRoot)} for "${token.value}"`,
 					);
 				}
 
@@ -601,25 +534,18 @@ export default class Parser {
 					}
 
 					// begin an AssigneesList node
-					this.beginExpressionWith(
-						MakeNode(NT.AssigneesList, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.AssigneesList, token, this.currentRoot, true));
 				}
 
 				if (this.debug) {
-					console.debug(
-						`Creating an Identifier Node in ${this.currentRoot.type} for "${token.value}"`,
-					);
+					console.debug(`Creating an Identifier Node in ${this.currentRoot.type} for "${token.value}"`);
 				}
 
 				this.addNode(MakeNode(NT.Identifier, token, this.currentRoot));
 
 				// check if currentRoot is a MemberExpression and next token is not a <| (types), and if so, it's finished
 				// since there may not be brackets. eg. `a.b` vs `a['b']`
-				if (
-					`${this.lexer.peek(0)}${this.lexer.peek(1)}` !==
-					tokenTypesUsingSymbols.triangle_open
-				) {
+				if (`${this.lexer.peek(0)}${this.lexer.peek(1)}` !== tokenTypesUsingSymbols.triangle_open) {
 					this.endExpressionIfIn(NT.MemberExpression);
 				}
 			} else if (token.type === 'comment') {
@@ -635,11 +561,7 @@ export default class Parser {
 				// end a TypeArgumentsList if we're in one
 				this.endExpressionIfIn(NT.TypeArgumentsList);
 
-				if (
-					!([NT.Parameter, NT.VariableDeclaration] as NT[]).includes(
-						this.currentRoot.type,
-					)
-				) {
+				if (!([NT.Parameter, NT.VariableDeclaration] as NT[]).includes(this.currentRoot.type)) {
 					// create an AssigneesList node taking the previous node as its child
 					{
 						const result = this.beginExpressionWithAdoptingPreviousNode(
@@ -667,25 +589,12 @@ export default class Parser {
 					// in pairs of two and check if they're an identifier and a comma
 					let oneSiblingBack = this.currentRoot.parent?.children.at(-2);
 					let twoSiblingsBack = this.currentRoot.parent?.children.at(-3);
-					while (
-						oneSiblingBack?.type === NT.CommaSeparator &&
-						twoSiblingsBack?.type === NT.Identifier
-					) {
+					while (oneSiblingBack?.type === NT.CommaSeparator && twoSiblingsBack?.type === NT.Identifier) {
 						// adopt the CommaSeparator and place it as the currentRoot's first grandchild
-						this.adoptNode(
-							this.currentRoot.parent,
-							oneSiblingBack,
-							this.currentRoot.children[0],
-							false,
-						);
+						this.adoptNode(this.currentRoot.parent, oneSiblingBack, this.currentRoot.children[0], false);
 
 						// adopt the Identifier and place it as the currentRoot's first grandchild
-						this.adoptNode(
-							this.currentRoot.parent,
-							twoSiblingsBack,
-							this.currentRoot.children[0],
-							false,
-						);
+						this.adoptNode(this.currentRoot.parent, twoSiblingsBack, this.currentRoot.children[0], false);
 
 						// keep on going back and checking for more identifiers and commas
 						// we don't have to decrement the index because each time a node
@@ -703,9 +612,7 @@ export default class Parser {
 					this.currentRoot.type === NT.AssignmentExpression
 				) {
 					// now begin an NT.AssignablesList node
-					this.beginExpressionWith(
-						MakeNode(NT.AssignablesList, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.AssignablesList, token, this.currentRoot, true));
 				}
 			} else if (token.type === 'plus') {
 				this.endExpressionIfIn(NT.UnaryExpression);
@@ -729,9 +636,7 @@ export default class Parser {
 					}
 				} else {
 					// otherwise this is a unary operator
-					this.beginExpressionWith(
-						MakeUnaryExpressionNode(token, true, this.currentRoot),
-					);
+					this.beginExpressionWith(MakeUnaryExpressionNode(token, true, this.currentRoot));
 				}
 			} else if (token.type === 'plus_plus' || token.type === 'minus_minus') {
 				// check token before, then check token after
@@ -747,9 +652,7 @@ export default class Parser {
 					}
 				} else {
 					// this is prefix
-					this.beginExpressionWith(
-						MakeUnaryExpressionNode(token, true, this.currentRoot),
-					);
+					this.beginExpressionWith(MakeUnaryExpressionNode(token, true, this.currentRoot));
 				}
 			} else if (token.type === 'asterisk') {
 				const result = this.handleBinaryExpression(token);
@@ -801,9 +704,7 @@ export default class Parser {
 					const [twoBack, twoBackType] = this.prev(2);
 					if (
 						twoBackType &&
-						([NT.Identifier, NT.MemberExpression, NT.ThisKeyword] as NT[]).includes(
-							twoBackType,
-						)
+						([NT.Identifier, NT.MemberExpression, NT.ThisKeyword] as NT[]).includes(twoBackType)
 					) {
 						// we're in a MemberExpression after the GenericTypesList
 						// eg. `foo<bar>.baz`
@@ -815,20 +716,12 @@ export default class Parser {
 							this.currentRoot,
 							true,
 						);
-						let wasAdopted = this.adoptNode(
-							this.currentRoot,
-							twoBack,
-							typeInstantiationExpressionNode,
-						);
+						let wasAdopted = this.adoptNode(this.currentRoot, twoBack, typeInstantiationExpressionNode);
 						if (wasAdopted.outcome === 'error') {
 							return error(wasAdopted.error);
 						}
 
-						wasAdopted = this.adoptNode(
-							this.currentRoot,
-							prev,
-							typeInstantiationExpressionNode,
-						);
+						wasAdopted = this.adoptNode(this.currentRoot, prev, typeInstantiationExpressionNode);
 						this.beginExpressionWith(typeInstantiationExpressionNode);
 						this.endExpression(); // end the TypeInstantiationExpression
 
@@ -866,13 +759,8 @@ export default class Parser {
 				if (this.currentRoot.type === NT.TernaryConsequent) {
 					// TernaryExpression
 					this.endExpression(); // end the TernaryConsequent
-					this.beginExpressionWith(
-						MakeNode(NT.TernaryAlternate, token, this.currentRoot, true),
-					);
-				} else if (
-					this.currentRoot.type === NT.ObjectExpression &&
-					this.prev()[1] === NT.Identifier
-				) {
+					this.beginExpressionWith(MakeNode(NT.TernaryAlternate, token, this.currentRoot, true));
+				} else if (this.currentRoot.type === NT.ObjectExpression && this.prev()[1] === NT.Identifier) {
 					// POJOs notation
 					const result = this.beginExpressionWithAdoptingPreviousNode(
 						MakeNode(NT.Property, token, this.currentRoot, true),
@@ -880,10 +768,7 @@ export default class Parser {
 					if (result.outcome === 'error') {
 						return result;
 					}
-				} else if (
-					this.currentRoot.type === NT.ObjectShape &&
-					this.prev()[1] === NT.Identifier
-				) {
+				} else if (this.currentRoot.type === NT.ObjectShape && this.prev()[1] === NT.Identifier) {
 					// POJOs notation
 					const result = this.beginExpressionWithAdoptingPreviousNode(
 						MakeNode(NT.PropertyShape, token, this.currentRoot, true),
@@ -908,9 +793,7 @@ export default class Parser {
 						this.addNode(MakeNode(NT.ColonSeparator, token, this.currentRoot));
 
 						if (this.currentRoot.type === NT.VariableDeclaration) {
-							this.beginExpressionWith(
-								MakeNode(NT.TypeArgumentsList, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.TypeArgumentsList, token, this.currentRoot, true));
 						}
 					}
 				}
@@ -933,10 +816,7 @@ export default class Parser {
 					this.endExpression();
 				} else if (this.currentRoot.type === NT.UnaryExpression) {
 					this.endExpression();
-				} else if (
-					this.currentRoot.type === NT.Parameter ||
-					this.currentRoot.type === NT.TypeParameter
-				) {
+				} else if (this.currentRoot.type === NT.Parameter || this.currentRoot.type === NT.TypeParameter) {
 					this.endExpression();
 				} else if (
 					this.currentRoot.type === NT.ClassExtension ||
@@ -944,10 +824,7 @@ export default class Parser {
 					this.currentRoot.type === NT.InterfaceExtension
 				) {
 					this.endExpression();
-				} else if (
-					this.currentRoot.type === NT.Property ||
-					this.currentRoot.type === NT.PropertyShape
-				) {
+				} else if (this.currentRoot.type === NT.Property || this.currentRoot.type === NT.PropertyShape) {
 					this.endExpression();
 				} else if (this.currentRoot.type === NT.RangeExpression) {
 					this.endExpression();
@@ -1012,16 +889,12 @@ export default class Parser {
 			} else if (token.type === 'right_arrow') {
 				if (this.currentRoot.type === NT.WhenCaseValues) {
 					this.endExpression();
-					this.beginExpressionWith(
-						MakeNode(NT.WhenCaseConsequent, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.WhenCaseConsequent, token, this.currentRoot, true));
 				} else if (
 					this.currentRoot.type === NT.FunctionDeclaration ||
 					this.currentRoot.type === NT.FunctionSignature
 				) {
-					this.beginExpressionWith(
-						MakeNode(NT.FunctionReturns, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.FunctionReturns, token, this.currentRoot, true));
 				} else {
 					this.addNode(MakeNode(NT.RightArrowOperator, token, this.currentRoot));
 				}
@@ -1066,16 +939,13 @@ export default class Parser {
 						] as NT[]
 					).includes(this.currentRoot.type)
 				) {
-					this.beginExpressionWith(
-						MakeNode(NT.TypeParametersList, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.TypeParametersList, token, this.currentRoot, true));
 				} else {
 					const [, prevType] = this.prev();
 					if (
 						this.currentRoot.type === NT.ArgumentsList ||
 						// foo.bar<|T|>
-						(this.currentRoot.type === NT.MemberExpression &&
-							prevType === NT.Identifier)
+						(this.currentRoot.type === NT.MemberExpression && prevType === NT.Identifier)
 					) {
 						const result = this.beginExpressionWithAdoptingPreviousNode(
 							MakeNode(NT.TypeInstantiationExpression, token, this.currentRoot, true),
@@ -1085,9 +955,7 @@ export default class Parser {
 						}
 					}
 
-					this.beginExpressionWith(
-						MakeNode(NT.TypeArgumentsList, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.TypeArgumentsList, token, this.currentRoot, true));
 				}
 			} else if (token.type === 'triangle_close') {
 				this.endExpressionIfIn(NT.TypeArgumentsList);
@@ -1102,12 +970,10 @@ export default class Parser {
 
 					if (
 						twoBackType &&
-						([NT.Identifier, NT.MemberExpression, NT.ThisKeyword] as NT[]).includes(
-							twoBackType,
+						([NT.Identifier, NT.MemberExpression, NT.ThisKeyword] as NT[]).includes(twoBackType) &&
+						!([NT.ClassExtension, NT.ClassImplement, NT.InterfaceExtension] as NT[]).includes(
+							this.currentRoot.type,
 						) &&
-						!(
-							[NT.ClassExtension, NT.ClassImplement, NT.InterfaceExtension] as NT[]
-						).includes(this.currentRoot.type) &&
 						this.lexer.peek(0) !== tokenTypesUsingSymbols.paren_open // CallExpression
 					) {
 						// we're in a MemberExpression after the GenericTypesList
@@ -1120,20 +986,12 @@ export default class Parser {
 							this.currentRoot,
 							true,
 						);
-						let wasAdopted = this.adoptNode(
-							this.currentRoot,
-							twoBack,
-							typeInstantiationExpressionNode,
-						);
+						let wasAdopted = this.adoptNode(this.currentRoot, twoBack, typeInstantiationExpressionNode);
 						if (wasAdopted.outcome === 'error') {
 							return error(wasAdopted.error);
 						}
 
-						wasAdopted = this.adoptNode(
-							this.currentRoot,
-							prev,
-							typeInstantiationExpressionNode,
-						);
+						wasAdopted = this.adoptNode(this.currentRoot, prev, typeInstantiationExpressionNode);
 						this.beginExpressionWith(typeInstantiationExpressionNode);
 						this.endExpression(); // end the TypeInstantiationExpression
 					}
@@ -1170,31 +1028,17 @@ export default class Parser {
 					NT.UnaryExpression,
 				];
 
-				if (
-					this.currentRoot.type === NT.FunctionReturns ||
-					this.currentRoot.type === NT.TypeArgumentsList
-				) {
-					this.beginExpressionWith(
-						MakeNode(NT.TupleShape, token, this.currentRoot, true),
-					);
+				if (this.currentRoot.type === NT.FunctionReturns || this.currentRoot.type === NT.TypeArgumentsList) {
+					this.beginExpressionWith(MakeNode(NT.TupleShape, token, this.currentRoot, true));
 				} else if (typeof prevType === 'undefined') {
 					// TupleExpression
-					this.beginExpressionWith(
-						MakeNode(NT.TupleExpression, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.TupleExpression, token, this.currentRoot, true));
 				} else if (this.currentRoot.type === NT.Property && prevType === NT.Identifier) {
 					// TupleExpression
-					this.beginExpressionWith(
-						MakeNode(NT.TupleExpression, token, this.currentRoot, true),
-					);
-				} else if (
-					this.currentRoot.type === NT.PropertyShape &&
-					prevType === NT.Identifier
-				) {
+					this.beginExpressionWith(MakeNode(NT.TupleExpression, token, this.currentRoot, true));
+				} else if (this.currentRoot.type === NT.PropertyShape && prevType === NT.Identifier) {
 					// TupleShape
-					this.beginExpressionWith(
-						MakeNode(NT.TupleShape, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.TupleShape, token, this.currentRoot, true));
 				} else if (nodeTypesThatPrecedeABinaryExpression.includes(prevType)) {
 					const result = this.beginExpressionWithAdoptingPreviousNode(
 						MakeNode(NT.BinaryExpression, token, this.currentRoot),
@@ -1202,10 +1046,7 @@ export default class Parser {
 					if (result.outcome === 'error') {
 						return result;
 					}
-				} else if (
-					prevType === NT.ArgumentsList &&
-					this.currentRoot.type === NT.CallExpression
-				) {
+				} else if (prevType === NT.ArgumentsList && this.currentRoot.type === NT.CallExpression) {
 					// we need to go 2 levels up
 					const result = this.beginExpressionWithAdoptingCurrentRoot(
 						MakeNode(NT.BinaryExpression, token, this.currentRoot),
@@ -1213,17 +1054,10 @@ export default class Parser {
 					if (result.outcome === 'error') {
 						return result;
 					}
-				} else if (
-					prevType === NT.ColonSeparator &&
-					this.currentRoot.type !== NT.ObjectExpression
-				) {
-					this.beginExpressionWith(
-						MakeNode(NT.TupleShape, token, this.currentRoot, true),
-					);
+				} else if (prevType === NT.ColonSeparator && this.currentRoot.type !== NT.ObjectExpression) {
+					this.beginExpressionWith(MakeNode(NT.TupleShape, token, this.currentRoot, true));
 				} else {
-					this.beginExpressionWith(
-						MakeNode(NT.TupleExpression, token, this.currentRoot, true),
-					);
+					this.beginExpressionWith(MakeNode(NT.TupleExpression, token, this.currentRoot, true));
 				}
 			} else if (token.type === 'more_than') {
 				/**
@@ -1240,10 +1074,7 @@ export default class Parser {
 
 				// then, then other stuff
 
-				if (
-					this.currentRoot.type === NT.TupleExpression ||
-					this.currentRoot.type === NT.TupleShape
-				) {
+				if (this.currentRoot.type === NT.TupleExpression || this.currentRoot.type === NT.TupleShape) {
 					this.endExpression(); // end the TupleExpression or TupleShape
 				} else {
 					// 'more than' BinaryExpression
@@ -1274,16 +1105,12 @@ export default class Parser {
 								console.debug('Beginning a ModifiersList');
 							}
 
-							this.beginExpressionWith(
-								MakeNode(NT.ModifiersList, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.ModifiersList, token, this.currentRoot, true));
 						}
 
 						if (this.debug) {
 							console.debug(
-								`Creating a Modifier Node in ${this.lineage(
-									this.currentRoot,
-								)} for "${token.value}"`,
+								`Creating a Modifier Node in ${this.lineage(this.currentRoot)} for "${token.value}"`,
 							);
 						}
 
@@ -1305,20 +1132,13 @@ export default class Parser {
 								);
 							} else {
 								if (this.debug) {
-									console.debug(
-										'There is no ModifiersList open; now beginning a ClassDeclaration',
-									);
+									console.debug('There is no ModifiersList open; now beginning a ClassDeclaration');
 								}
 
 								// beginExpressionWith doesn't result a Result<>
 								classNode = ok(
 									this.beginExpressionWith(
-										MakeNode(
-											NT.ClassDeclaration,
-											token,
-											this.currentRoot,
-											true,
-										),
+										MakeNode(NT.ClassDeclaration, token, this.currentRoot, true),
 									),
 								);
 							}
@@ -1358,9 +1178,7 @@ export default class Parser {
 								}
 
 								variableNode = ok(
-									this.beginExpressionWith(
-										MakeNode(NT.VariableDeclaration, token, this.currentRoot),
-									),
+									this.beginExpressionWith(MakeNode(NT.VariableDeclaration, token, this.currentRoot)),
 								);
 							}
 
@@ -1396,9 +1214,7 @@ export default class Parser {
 						break;
 					case 'extends':
 						if (this.currentRoot.type === NT.ClassDeclaration) {
-							this.beginExpressionWith(
-								MakeNode(NT.ClassExtensionsList, token, this.currentRoot, true),
-							);
+							this.beginExpressionWith(MakeNode(NT.ClassExtensionsList, token, this.currentRoot, true));
 						} else if (this.currentRoot.type === NT.InterfaceDeclaration) {
 							this.beginExpressionWith(
 								MakeNode(NT.InterfaceExtensionsList, token, this.currentRoot, true),
@@ -1442,23 +1258,13 @@ export default class Parser {
 								) {
 									fNode = ok(
 										this.beginExpressionWith(
-											MakeNode(
-												NT.FunctionSignature,
-												token,
-												this.currentRoot,
-												true,
-											),
+											MakeNode(NT.FunctionSignature, token, this.currentRoot, true),
 										),
 									);
 								} else {
 									fNode = ok(
 										this.beginExpressionWith(
-											MakeNode(
-												NT.FunctionDeclaration,
-												token,
-												this.currentRoot,
-												true,
-											),
+											MakeNode(NT.FunctionDeclaration, token, this.currentRoot, true),
 										),
 									);
 								}
@@ -1479,9 +1285,7 @@ export default class Parser {
 						this.addNode(MakeNode(NT.FromKeyword, token, this.currentRoot, true));
 						break;
 					case 'for':
-						this.beginExpressionWith(
-							MakeNode(NT.ForStatement, token, this.currentRoot, true),
-						);
+						this.beginExpressionWith(MakeNode(NT.ForStatement, token, this.currentRoot, true));
 						break;
 					case 'if':
 						{
@@ -1521,9 +1325,7 @@ export default class Parser {
 									this.endExpression(); // end the IfStatement
 								}
 
-								this.beginExpressionWith(
-									MakeNode(NT.IfStatement, token, this.currentRoot, true),
-								);
+								this.beginExpressionWith(MakeNode(NT.IfStatement, token, this.currentRoot, true));
 							}
 						}
 						break;
@@ -1531,14 +1333,10 @@ export default class Parser {
 						this.endExpressionIfIn(NT.ClassExtension);
 						this.endExpressionIfIn(NT.ClassExtensionsList);
 
-						this.beginExpressionWith(
-							MakeNode(NT.ClassImplementsList, token, this.currentRoot, true),
-						);
+						this.beginExpressionWith(MakeNode(NT.ClassImplementsList, token, this.currentRoot, true));
 						break;
 					case 'import':
-						this.beginExpressionWith(
-							MakeNode(NT.ImportDeclaration, token, this.currentRoot, true),
-						);
+						this.beginExpressionWith(MakeNode(NT.ImportDeclaration, token, this.currentRoot, true));
 						break;
 					case 'in':
 						{
@@ -1591,9 +1389,7 @@ export default class Parser {
 						}
 						break;
 					case 'loop':
-						this.beginExpressionWith(
-							MakeNode(NT.LoopStatement, token, this.currentRoot, true),
-						);
+						this.beginExpressionWith(MakeNode(NT.LoopStatement, token, this.currentRoot, true));
 						break;
 					case 'next':
 						this.addNode(MakeNode(NT.NextStatement, token, this.currentRoot, true));
@@ -1609,19 +1405,13 @@ export default class Parser {
 						}
 						break;
 					case 'print':
-						this.beginExpressionWith(
-							MakeNode(NT.PrintStatement, token, this.currentRoot, true),
-						);
+						this.beginExpressionWith(MakeNode(NT.PrintStatement, token, this.currentRoot, true));
 						break;
 					case 'return':
-						this.beginExpressionWith(
-							MakeNode(NT.ReturnStatement, token, this.currentRoot, true),
-						);
+						this.beginExpressionWith(MakeNode(NT.ReturnStatement, token, this.currentRoot, true));
 						break;
 					case 'when':
-						this.beginExpressionWith(
-							MakeNode(NT.WhenExpression, token, this.currentRoot, true),
-						);
+						this.beginExpressionWith(MakeNode(NT.WhenExpression, token, this.currentRoot, true));
 						break;
 					default:
 						return error(
@@ -1656,9 +1446,7 @@ export default class Parser {
 				}
 
 				this.endExpression(); // end the TernaryCondition
-				this.beginExpressionWith(
-					MakeNode(NT.TernaryConsequent, token, this.currentRoot, true),
-				);
+				this.beginExpressionWith(MakeNode(NT.TernaryConsequent, token, this.currentRoot, true));
 			} else {
 				return error(
 					new ParserError(
@@ -1714,9 +1502,7 @@ export default class Parser {
 
 		if (this.currentRoot.type === NT.BinaryExpression && ['and', 'or'].includes(token.type)) {
 			// && and || have higher order precedence than equality checks
-			return this.beginExpressionWithAdoptingCurrentRoot(
-				MakeNode(NT.BinaryExpression, token, this.currentRoot),
-			);
+			return this.beginExpressionWithAdoptingCurrentRoot(MakeNode(NT.BinaryExpression, token, this.currentRoot));
 		} else {
 			return this.beginExpressionWithAdoptingPreviousNode(
 				MakeNode(NT.BinaryExpression, token, this.currentRoot),
@@ -1734,10 +1520,7 @@ export default class Parser {
 	}
 
 	private ifInWhenExpressionBlockStatementBeginCase(token: Token) {
-		if (
-			this.currentRoot.type === NT.BlockStatement &&
-			this.currentRoot.parent?.type === NT.WhenExpression
-		) {
+		if (this.currentRoot.type === NT.BlockStatement && this.currentRoot.parent?.type === NT.WhenExpression) {
 			this.beginExpressionWith(MakeNode(NT.WhenCase, token, this.currentRoot, true));
 			this.beginExpressionWith(MakeNode(NT.WhenCaseValues, token, this.currentRoot, true));
 		}
@@ -1854,10 +1637,7 @@ export default class Parser {
 	 *
 	 * @returns A response error if there is no previous node
 	 */
-	private beginExpressionWithAdoptingPreviousNode(
-		newKid: Node,
-		whatWeExpectInPrevNode?: string,
-	): Result<Node> {
+	private beginExpressionWithAdoptingPreviousNode(newKid: Node, whatWeExpectInPrevNode?: string): Result<Node> {
 		return this.beginExpressionWithAdopting(newKid, this.prev()[0], whatWeExpectInPrevNode);
 	}
 
@@ -1957,9 +1737,7 @@ export default class Parser {
 
 				if (this.debug) {
 					console.debug(
-						`Finished moving this.currentRoot; this.currentRoot is now ${this.lineage(
-							this.currentRoot,
-						)}`,
+						`Finished moving this.currentRoot; this.currentRoot is now ${this.lineage(this.currentRoot)}`,
 					);
 				}
 

--- a/parser/simplifier.ts
+++ b/parser/simplifier.ts
@@ -11,12 +11,7 @@ type SParseNodeWithValueAndWithoutChildren = [NT, string]; // eg [NodeType.Numbe
 type SParseNodeWithoutValueWithChildren = [NT, SParseTree]; // eg ['ArgumentList', [...]]
 type SParseNodeWithoutValueWithChildrenWithExtraInformation = [NT, extraInformation, SParseTree]; // eg [NodeType.IfStatement, {before}, [...]]
 type SParseNodeWithValueWithChildren = [NT, string, SParseTree]; // eg [NodeType.BinaryExpression, '==', [...]]
-type SParseNodeWithValueWithChildrenWithExtraInformation = [
-	NT,
-	string,
-	extraInformation,
-	SParseTree,
-]; // eg [NodeType.UnaryExpression, '++', {before}, [...]]
+type SParseNodeWithValueWithChildrenWithExtraInformation = [NT, string, extraInformation, SParseTree]; // eg [NodeType.UnaryExpression, '++', {before}, [...]]
 type SParseNode =
 	| SParseNodeWithoutValueAndWithoutChildren
 	| SParseNodeWithValueAndWithoutChildren
@@ -33,11 +28,7 @@ export const simplifyTree = (nodes: Node[]): SParseTree => {
 		// a node will have either a value, or children, or both, or neither
 		let hasValue = typeof node.value !== 'undefined';
 		// in a few cases, we really don't need the value
-		if (
-			node.type === NT.ColonSeparator ||
-			node.type === NT.CommaSeparator ||
-			node.type === NT.SemicolonSeparator
-		) {
+		if (node.type === NT.ColonSeparator || node.type === NT.CommaSeparator || node.type === NT.SemicolonSeparator) {
 			hasValue = false;
 		}
 

--- a/parser/types.ts
+++ b/parser/types.ts
@@ -107,11 +107,7 @@ export const ExpressionNodeTypes: NT[] = [
 ];
 
 /** These are Node Types that are physically assignable to some variable, param, or in a return. */
-export const AssignableNodeTypes: NT[] = [
-	...ExpressionNodeTypes,
-	NT.FunctionDeclaration,
-	NT.ThisKeyword,
-];
+export const AssignableNodeTypes: NT[] = [...ExpressionNodeTypes, NT.FunctionDeclaration, NT.ThisKeyword];
 
 /** These are the Types corresponding to AssignableNodeTypes */
 export const AssignableTypes: NT[] = [
@@ -148,9 +144,9 @@ export const validNodeTypesAsMemberObject = [
 
 export const validChildrenAsMemberProperty = [
 	NT.BinaryExpression, // eg. foo[index + 1]
-	NT.CallExpression, // eg. foo[bar() -> number]
+	NT.CallExpression, // eg. foo[bar() -> int64]
 	NT.CommaSeparator, // eg. foo[bar, baz]
-	NT.Identifier, // eg. foo[bar: number]
+	NT.Identifier, // eg. foo[bar: int32]
 	NT.MemberExpression, // eg. foo[bar.baz]
 	NT.NumberLiteral, // eg. foo[1]
 	NT.RangeExpression, // eg. foo[1 .. 2]

--- a/semanticAnalysis/error.ts
+++ b/semanticAnalysis/error.ts
@@ -11,7 +11,7 @@ export enum AnalysisErrorCode {
 	MissingPreviousNode = 'S001',
 	MissingParentNode = 'S002',
 	ExtraNodesFound = 'S003',
-	MissingVisitee = 'S004',
+	MissingVisitee = 'S004', // TODO remove this
 	IdentifierExpected = 'S005',
 	KeywordExpected = 'S006',
 	ExpressionExpected = 'S007',
@@ -61,12 +61,7 @@ export default class AnalysisError extends TypeError {
 	private node;
 	private context;
 
-	constructor(
-		errorCode: AnalysisErrorCode,
-		message: string,
-		node: Node | undefined,
-		context: ErrorContext,
-	) {
+	constructor(errorCode: AnalysisErrorCode, message: string, node: Node | undefined, context: ErrorContext) {
 		super(message);
 
 		this.errorCode = errorCode;

--- a/semanticAnalysis/semanticAnalyzer.spec.ts
+++ b/semanticAnalysis/semanticAnalyzer.spec.ts
@@ -1,0 +1,29 @@
+// write tests for semanticAnalyzer
+
+import { ASTNumberLiteral } from './asts';
+
+// Path: semanticAnalysis/semanticAnalyzer.ts
+
+describe('semanticAnalyzer', () => {
+	describe('ASTNumberLiteral', () => {
+		describe('convertNumberValueTo', () => {
+			it('should convert a number value to an AST number literal', () => {
+				const numberValue = '10';
+				const astNumberLiteral = ASTNumberLiteral.convertNumberValueTo(numberValue);
+				expect(astNumberLiteral).toEqual({
+					outcome: 'ok',
+					value: ASTNumberLiteral._(10, undefined, [
+						'int8',
+						'int16',
+						'int32',
+						'int64',
+						'uint8',
+						'uint16',
+						'uint32',
+						'uint64',
+					]),
+				});
+			});
+		});
+	});
+});

--- a/semanticAnalysis/visitorMap.ts
+++ b/semanticAnalysis/visitorMap.ts
@@ -9,16 +9,14 @@ const visitorMap: Record<NT, visitor> = {
 		analyzer.visitArgumentList(node) as Result<T>,
 	[NT.ArrayExpression]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitArrayExpression(node) as Result<T>,
-	[NT.ArrayOf]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.visitArrayOf(node) as Result<T>,
+	[NT.ArrayOf]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.visitArrayOf(node) as Result<T>,
 	[NT.AssignablesList]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitAssignablesList(node) as Result<T>,
 	[NT.AssigneesList]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitAssigneesList(node) as Result<T>,
 	[NT.AssignmentExpression]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitAssignmentExpression(node) as Result<T>,
-	[NT.AssignmentOperator]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.noop(node) as Result<T>,
+	[NT.AssignmentOperator]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.noop(node) as Result<T>,
 	[NT.BinaryExpression]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitBinaryExpression(node) as Result<T>,
 	[NT.BlockStatement]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
@@ -37,20 +35,16 @@ const visitorMap: Record<NT, visitor> = {
 		analyzer.visitClassOrInterfaceExtendsOrImplements(node) as Result<T>,
 	[NT.ClassImplementsList]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitClassImplementsList(node) as Result<T>,
-	[NT.ColonSeparator]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.noop(node) as Result<T>,
-	[NT.CommaSeparator]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.noop(node) as Result<T>,
-	[NT.Comment]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.noop(node) as Result<T>,
+	[NT.ColonSeparator]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.noop(node) as Result<T>,
+	[NT.CommaSeparator]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.noop(node) as Result<T>,
+	[NT.Comment]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.noop(node) as Result<T>,
 	[NT.DoneStatement]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitDoneStatement(node) as Result<T>,
 	[NT.ElseStatement]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitElseStatement(node) as Result<T>,
 	[NT.ForStatement]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitForStatement(node) as Result<T>,
-	[NT.FromKeyword]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.noop(node) as Result<T>,
+	[NT.FromKeyword]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.noop(node) as Result<T>,
 	[NT.FunctionDeclaration]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitFunctionDeclaration(node) as Result<T>,
 	[NT.FunctionReturns]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
@@ -63,16 +57,14 @@ const visitorMap: Record<NT, visitor> = {
 		analyzer.visitIfStatement(node) as Result<T>,
 	[NT.ImportDeclaration]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitImportDeclaration(node) as Result<T>,
-	[NT.InKeyword]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.noop(node) as Result<T>,
+	[NT.InKeyword]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.noop(node) as Result<T>,
 	[NT.InterfaceDeclaration]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitInterfaceDeclaration(node) as Result<T>,
 	[NT.InterfaceExtension]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitClassOrInterfaceExtendsOrImplements(node) as Result<T>,
 	[NT.InterfaceExtensionsList]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitInterfaceExtensionsList(node) as Result<T>,
-	[NT.JoeDoc]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.visitJoeDoc(node) as Result<T>,
+	[NT.JoeDoc]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.visitJoeDoc(node) as Result<T>,
 	[NT.LoopStatement]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitLoopStatement(node) as Result<T>,
 	[NT.MemberExpression]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
@@ -81,8 +73,7 @@ const visitorMap: Record<NT, visitor> = {
 		analyzer.visitMemberList(node) as Result<T>,
 	[NT.MemberListExpression]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitMemberListExpression(node) as Result<T>,
-	[NT.Modifier]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.visitModifier(node) as Result<T>,
+	[NT.Modifier]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.visitModifier(node) as Result<T>,
 	[NT.ModifiersList]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitModifiersList(node) as Result<T>,
 	[NT.NextStatement]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
@@ -99,16 +90,13 @@ const visitorMap: Record<NT, visitor> = {
 		analyzer.visitParametersList(node) as Result<T>,
 	[NT.Parenthesized]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitParenthesized(node) as Result<T>,
-	[NT.Path]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.visitPath(node) as Result<T>,
+	[NT.Path]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.visitPath(node) as Result<T>,
 	[NT.PostfixIfStatement]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitPostfixIfStatement(node) as Result<T>,
 	[NT.PrintStatement]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitPrintStatement(node) as Result<T>,
-	[NT.Program]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.visitProgram(node) as Result<T>,
-	[NT.Property]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.visitProperty(node) as Result<T>,
+	[NT.Program]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.visitProgram(node) as Result<T>,
+	[NT.Property]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.visitProperty(node) as Result<T>,
 	[NT.PropertyShape]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitPropertyShape(node) as Result<T>,
 	[NT.RangeExpression]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
@@ -119,10 +107,8 @@ const visitorMap: Record<NT, visitor> = {
 		analyzer.visitRestElement(node) as Result<T>,
 	[NT.ReturnStatement]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitReturnStatement(node) as Result<T>,
-	[NT.RightArrowOperator]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.noop(node) as Result<T>,
-	[NT.SemicolonSeparator]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.noop(node) as Result<T>,
+	[NT.RightArrowOperator]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.noop(node) as Result<T>,
+	[NT.SemicolonSeparator]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.noop(node) as Result<T>,
 	[NT.StringLiteral]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitStringLiteral(node) as Result<T>,
 	[NT.TernaryAlternate]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
@@ -139,8 +125,7 @@ const visitorMap: Record<NT, visitor> = {
 		analyzer.visitTupleExpression(node) as Result<T>,
 	[NT.TupleShape]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitTupleShape(node) as Result<T>,
-	[NT.Type]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.visitType(node) as Result<T>,
+	[NT.Type]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.visitType(node) as Result<T>,
 	[NT.TypeArgumentsList]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitTypeArgumentsList(node) as Result<T>,
 	[NT.TypeInstantiationExpression]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
@@ -153,8 +138,7 @@ const visitorMap: Record<NT, visitor> = {
 		analyzer.visitUnaryExpression(node as UnaryExpressionNode) as Result<T>,
 	[NT.VariableDeclaration]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitVariableDeclaration(node) as Result<T>,
-	[NT.WhenCase]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
-		analyzer.visitWhenCase(node) as Result<T>,
+	[NT.WhenCase]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> => analyzer.visitWhenCase(node) as Result<T>,
 	[NT.WhenCaseConsequent]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>
 		analyzer.visitWhenCaseConsequent(node) as Result<T>,
 	[NT.WhenCaseValues]: <T>(node: Node, analyzer: SemanticAnalyzer): Result<T> =>

--- a/setupJest.ts
+++ b/setupJest.ts
@@ -52,10 +52,7 @@ export type SToken = [
 	value: string,
 ];
 
-function matchTokens(
-	tokensResult: Result<Token[]>,
-	simplifiedVersion: SToken[],
-): CustomMatcherResult {
+function matchTokens(tokensResult: Result<Token[]>, simplifiedVersion: SToken[]): CustomMatcherResult {
 	switch (tokensResult.outcome) {
 		case 'ok':
 			{
@@ -76,9 +73,7 @@ function matchTokens(
 				}
 
 				// first convert tokens to simplified tokens, where we only need the type and value
-				const simplifiedTokens = tokensResult.value.map(
-					(token: Token): SToken => [token.type, token.value],
-				);
+				const simplifiedTokens = tokensResult.value.map((token: Token): SToken => [token.type, token.value]);
 
 				try {
 					expect(simplifiedTokens).toStrictEqual(simplifiedVersion);
@@ -88,9 +83,9 @@ function matchTokens(
 					return {
 						pass: false,
 						message: () =>
-							`they do not match. Expected: ${JSON.stringify(
-								simplifiedVersion,
-							)}, Got: ${JSON.stringify(simplifiedTokens)}`,
+							`they do not match. Expected: ${JSON.stringify(simplifiedVersion)}, Got: ${JSON.stringify(
+								simplifiedTokens,
+							)}`,
 					};
 				}
 			}
@@ -108,10 +103,7 @@ expect.extend({
 // Parser Stuff
 ////////////////////////////////////////////////////////////
 
-export function matchParseTree(
-	treeResult: Result<Node>,
-	simplifiedVersion: SParseTree,
-): CustomMatcherResult {
+export function matchParseTree(treeResult: Result<Node>, simplifiedVersion: SParseTree): CustomMatcherResult {
 	switch (treeResult.outcome) {
 		case 'ok':
 			{
@@ -142,7 +134,7 @@ export function matchParseTree(
 					return {
 						pass: false,
 						message: () =>
-							`the parse trees do not match. (Minus in red is what what expected, plus in green is what was received). Diff:\n${diff}`,
+							`the parse trees do not match. (Plus in green is what was received, minus in red is what was expected). Diff:\n${diff}`,
 					};
 				}
 			}
@@ -189,7 +181,7 @@ export function matchAST(
 					return {
 						pass: false,
 						message: () =>
-							`the ASTs do not match. (Minus in red is what what expected, plus in green is what was received). Diff:\n${diff}`,
+							`the ASTs do not match. (Plus in green is what was received, minus in red is what was expected). Diff:\n${diff}`,
 					};
 				}
 			}
@@ -213,9 +205,7 @@ function diffObjects(expected: any, received: any, path = ''): string {
 	const receivedKeys = Object.keys(received);
 	const addedKeys = receivedKeys.filter((key) => !expectedKeys.includes(key));
 	const removedKeys = expectedKeys.filter((key) => !receivedKeys.includes(key));
-	const changedKeys = expectedKeys.filter(
-		(key) => receivedKeys.includes(key) && expected[key] !== received[key],
-	);
+	const changedKeys = expectedKeys.filter((key) => receivedKeys.includes(key) && expected[key] !== received[key]);
 
 	let output = '';
 
@@ -278,12 +268,7 @@ function diffArrays(expected: any[], received: any[], path = ''): string {
 function stringify(obj: any): string {
 	if (typeof obj === 'string') {
 		return `"${obj}"`;
-	} else if (
-		typeof obj === 'number' ||
-		typeof obj === 'boolean' ||
-		obj === null ||
-		obj === undefined
-	) {
+	} else if (typeof obj === 'number' || typeof obj === 'boolean' || obj === null || obj === undefined) {
 		return String(obj);
 	} else if (Array.isArray(obj)) {
 		const elements = obj.map((element) => stringify(element)).join(', ');

--- a/shared/errorContext.ts
+++ b/shared/errorContext.ts
@@ -50,9 +50,7 @@ export default class ErrorContext {
 				  }
 				: undefined;
 
-		const prefix = `${' '.repeat(
-			(nextLine?.number ?? currentLine.number).toString().length,
-		)} |`;
+		const prefix = `${' '.repeat((nextLine?.number ?? currentLine.number).toString().length)} |`;
 
 		const lineToString = (line: Line): string => `${line.number} | ${line.content}`;
 

--- a/shared/numbers/sizes.ts
+++ b/shared/numbers/sizes.ts
@@ -1,0 +1,81 @@
+export type BitCount = 8 | 16 | 32 | 64; // TODO add support for 128 bit numbers
+
+type SizeInfo = {
+	type: 'int' | 'uint' | 'dec';
+	bits: BitCount;
+	min: number;
+	max: number | bigint;
+};
+
+export const numberSizesSignedInts = ['int8', 'int16', 'int32', 'int64'] as const;
+export const numberSizesUnsignedInts = ['uint8', 'uint16', 'uint32', 'uint64'] as const;
+export const numberSizesInts = [...numberSizesSignedInts, ...numberSizesUnsignedInts] as const;
+export const numberSizesDecimals = ['dec32', 'dec64'] as const;
+export const numberSizesAll = [...numberSizesInts, ...numberSizesDecimals] as const;
+export type NumberSize = (typeof numberSizesAll)[number];
+
+export const numberSizeDetails: Record<NumberSize, SizeInfo> = {
+	int8: {
+		type: 'int',
+		bits: 8,
+		min: -128,
+		max: 127,
+	},
+	int16: {
+		type: 'int',
+		bits: 16,
+		min: -32768,
+		max: 32767,
+	},
+	int32: {
+		type: 'int',
+		bits: 32,
+		min: -2147483648,
+		max: 2147483647,
+	},
+	int64: {
+		type: 'int',
+		bits: 64,
+		min: -9223372036854775808,
+		max: 9223372036854775807n,
+	},
+	uint8: {
+		type: 'uint',
+		bits: 8,
+		min: 0,
+		max: 255,
+	},
+	uint16: {
+		type: 'uint',
+		bits: 16,
+		min: 0,
+		max: 65535,
+	},
+	uint32: {
+		type: 'uint',
+		bits: 32,
+		min: 0,
+		max: 4294967295,
+	},
+	uint64: {
+		type: 'uint',
+		bits: 64,
+		min: 0,
+		max: 18446744073709551615n,
+	},
+	dec32: {
+		type: 'dec',
+		bits: 32,
+		// eslint-disable-next-line prettier/prettier
+		min: -0.000000e-95,
+		max: 9.999999e96,
+	},
+	dec64: {
+		type: 'dec',
+		bits: 64,
+		// eslint-disable-next-line prettier/prettier
+		min: -0.000000000000000e-383,
+		// eslint-disable-next-line @typescript-eslint/no-loss-of-precision
+		max: 9.999999999999999e384,
+	},
+};

--- a/shared/numbers/utils.ts
+++ b/shared/numbers/utils.ts
@@ -1,0 +1,103 @@
+import { ASTTypeNumber } from '../../semanticAnalysis/asts';
+import { error, ok, Result } from '../result';
+import { BitCount, NumberSize, numberSizeDetails } from './sizes';
+
+/**
+ * Gets the lowest bit count of number sizes. This method must have at least one number size.
+ *
+ * @param requiredNumberSize First number size to compare
+ * @param optionalMoreNumberSizes More number sizes to compare
+ * @returns A number bit size that is the lowest bit size of all the number sizes
+ */
+export const getLowestBitCountOf = (
+	requiredNumberSize: NumberSize,
+	...optionalMoreNumberSizes: NumberSize[]
+): BitCount => {
+	const bitCounts = [requiredNumberSize, ...optionalMoreNumberSizes].map(
+		(numberSize) => numberSizeDetails[numberSize].bits,
+	);
+
+	return Math.min(...bitCounts) as BitCount;
+};
+
+/** Determines the possible sizes of a number */
+export const determinePossibleNumberSizes = (value: string): Result<NumberSize[]> => {
+	// remove underscores
+	value = value.replace(/_/g, '');
+
+	const possibleSizes: NumberSize[] = [];
+
+	if (value.includes('.')) {
+		const num = parseFloat(value);
+
+		if (num >= numberSizeDetails.dec32.min && num <= numberSizeDetails.dec32.max) {
+			possibleSizes.push('dec32');
+		}
+
+		if (num >= numberSizeDetails.dec64.min && num <= numberSizeDetails.dec64.max) {
+			possibleSizes.push('dec64');
+		}
+
+		if (possibleSizes.length > 0) {
+			return ok(possibleSizes);
+		}
+
+		return error(new Error(`Invalid decimal: ${value}`));
+	}
+
+	const num = parseInt(value);
+
+	if (num >= numberSizeDetails.int8.min && num <= numberSizeDetails.int8.max) {
+		possibleSizes.push('int8');
+	}
+
+	if (num >= numberSizeDetails.int16.min && num <= numberSizeDetails.int16.max) {
+		possibleSizes.push('int16');
+	}
+
+	if (num >= numberSizeDetails.int32.min && num <= numberSizeDetails.int32.max) {
+		possibleSizes.push('int32');
+	}
+
+	if (num >= numberSizeDetails.int64.min && num <= numberSizeDetails.int64.max) {
+		possibleSizes.push('int64');
+	}
+
+	if (num >= numberSizeDetails.uint8.min && num <= numberSizeDetails.uint8.max) {
+		possibleSizes.push('uint8');
+	}
+
+	if (num >= numberSizeDetails.uint16.min && num <= numberSizeDetails.uint16.max) {
+		possibleSizes.push('uint16');
+	}
+
+	if (num >= numberSizeDetails.uint32.min && num <= numberSizeDetails.uint32.max) {
+		possibleSizes.push('uint32');
+	}
+
+	if (num >= numberSizeDetails.uint64.min && num <= numberSizeDetails.uint64.max) {
+		possibleSizes.push('uint64');
+	}
+
+	if (possibleSizes.length > 0) {
+		return ok(possibleSizes);
+	}
+
+	return error(new Error(`Invalid int: ${value}`));
+};
+
+/**
+ * Filters ASTTypeNumbers with bit counts lower than a given bit count.
+ * @param asts ASTs to filter
+ * @param bitCount Bit count to filter by
+ * @returns ASTs with bit counts equal to or higher than the given bit count
+ *
+ * @example
+ * filterASTTypeNumbersWithBitCountsLowerThan([ASTTypeNumber._('uint8'), ASTTypeNumber._('int16')], 16) // returns [ASTTypeNumber._('int16')]
+ */
+export const filterASTTypeNumbersWithBitCountsLowerThan = (
+	asts: ASTTypeNumber[],
+	bitCount: BitCount,
+): ASTTypeNumber[] => {
+	return asts.filter((ast) => numberSizeDetails[ast.size].bits >= bitCount);
+};

--- a/shared/result.ts
+++ b/shared/result.ts
@@ -20,10 +20,7 @@ export function ok<T>(value: T): Result<T> {
 }
 
 /** Shortcut to create an error Result */
-export function error<T, E extends Error = Error, ED = unknown>(
-	error: E,
-	data?: ED,
-): Result<T, E, ED> {
+export function error<T, E extends Error = Error, ED = unknown>(error: E, data?: ED): Result<T, E, ED> {
 	return { outcome: 'error', error, data };
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
This PR:

* Adds Number Sizes: `int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, `uint64`, `dec32`, `dec64`
* Updates lexer to recognize these as types instead of `number`
* Numbers can specify the size: eg. `12_int64`
* Changes to ASTs:
  * `ASTArrayExpression.type` to `.possibleTypes`
  * `ASTNumberLiteral.format` to `.declaredSize?` and `.possibleSizes`
  * `ASTObjectExpression.type` to `.possibleTypes`
  * `ASTParameter.inferredType` to `.inferredPossibleTypes`
  * `ASTPropertyShape.type` to `.possibleTypes`
  * `ASTTupleShape.types` to `.possibleTypes`
  * replace `ASTTypePrimitiveNumber` with `ASTTypeNumber`
  * `ASTVariableDeclaration.inferredTypes` to `.inferredPossibleTypes`
* New helper function `astUniqueness()` to give a unique string representing the type of AST node

Other changes:
* Increases prettier line width to 120
* Swap commas for underscores in numbers, so instead of `1,234` you'll use `1_234`
* Fixes jest output for custom matchers
* Updates tsconfig target to `"ESNext"`
* 